### PR TITLE
feat: add reentrant window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "vulnerable/unchecked_math",
     "vulnerable/unprotected_admin",
     "vulnerable/unsafe_storage",
+    "vulnerable/reentrancy",
     "vulnerable/div_by_zero",
     "secure/secure_vault",
     "secure/protected_admin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "vulnerable/missing_auth",
     "vulnerable/missing_events",
+    "vulnerable/missing_ttl",
     "vulnerable/timestamp_lock",
     "vulnerable/unchecked_math",
     "vulnerable/unprotected_admin",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ soroban-guard-contracts/
 ├── vulnerable/
 │   ├── missing_auth/       # transfer() with no require_auth()
 │   ├── unchecked_math/     # staking rewards with raw u64 arithmetic
+│   ├── missing_ttl/        # persistent balances expire because TTL is never renewed
 │   ├── unprotected_admin/  # set_admin() / upgrade() open to anyone
 │   └── unsafe_storage/     # public writes to any account's storage slot
 ├── secure/
@@ -45,6 +46,7 @@ soroban-guard-contracts/
 | Crate | Context | Vulnerability |
 |---|---|---|
 | `missing_auth` | Token contract | `transfer()` mutates balances without `require_auth()` |
+| `missing_ttl` | Token contract | Persistent balances expire because the contract never calls `extend_ttl()` |
 | `unchecked_math` | Staking contract | Reward calc uses raw `*` on `u64` — overflows silently |
 | `unprotected_admin` | Escrow contract | `set_admin()` and `upgrade()` have no caller check |
 | `unsafe_storage` | KYC registry | Any caller can write to any account's storage slot |

--- a/docs/vulnerabilities.md
+++ b/docs/vulnerabilities.md
@@ -192,6 +192,48 @@ pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
 
 ---
 
+## 6. Missing TTL Renewal (`missing_ttl`)
+
+**Contract:** `vulnerable/missing_ttl` → secure mirror in `vulnerable/missing_ttl/src/secure.rs`
+
+### What it is
+
+Soroban persistent storage entries are not permanent by default. Every entry has
+a ledger TTL, and once that window passes the entry expires unless the contract
+refreshes it with `env.storage().persistent().extend_ttl(...)`.
+
+### Vulnerable code
+
+```rust
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth();
+    // ❌ No extend_ttl — active balances are never renewed
+    env.storage().persistent().set(&from_key, &new_from);
+    env.storage().persistent().set(&to_key, &new_to);
+}
+```
+
+### Secure fix
+
+```rust
+let balance: Option<i128> = env.storage().persistent().get(&key);
+if balance.is_some() {
+    env.storage().persistent().extend_ttl(&key, threshold, extend_to); // ✅ renew on read
+}
+
+env.storage().persistent().set(&key, &amount);
+env.storage().persistent().extend_ttl(&key, threshold, extend_to); // ✅ renew on write
+```
+
+### Impact
+
+- Liveness failure: after roughly the network's max TTL window, balances or
+  records disappear and the contract starts reading them as missing.
+- Funds are not stolen, but they can become permanently inaccessible.
+- Severity: **Low**
+
+---
+
 ## General Soroban Security Checklist
 
 | Check                               | Description                                                                                              |
@@ -201,3 +243,4 @@ pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
 | Admin gate on privileged fns        | `initialize`, `upgrade`, `set_admin`, `pause` must verify the caller is the stored admin                 |
 | Storage key ownership               | Storage keys that include an `Address` must only be written after `address.require_auth()`               |
 | No re-initialization                | Guard `initialize` with a check that the contract hasn't already been set up                             |
+| TTL renewal for persistent entries  | Long-lived state should call `persistent().extend_ttl(...)` on active reads/writes to avoid expiry      |

--- a/vulnerable/missing_ttl/Cargo.toml
+++ b/vulnerable/missing_ttl/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "missing-ttl"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/missing_ttl/src/lib.rs
+++ b/vulnerable/missing_ttl/src/lib.rs
@@ -1,0 +1,206 @@
+//! VULNERABLE: Missing Persistent Storage TTL Renewal
+//!
+//! Soroban persistent storage entries expire after their ledger TTL window.
+//! This token stores balances in persistent storage but never calls
+//! `env.storage().persistent().extend_ttl(...)`, so inactive balances
+//! eventually disappear.
+//!
+//! VULNERABILITY: after roughly the network's `max_entry_expiration` / max TTL
+//! window, balance entries expire and `balance()` falls back to `0`, making
+//! funds or data permanently inaccessible.
+//!
+//! Severity: Low (liveness, not direct fund theft)
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Balance(Address),
+}
+
+fn get_balance(env: &Env, account: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(account.clone()))
+        .unwrap_or(0)
+}
+
+fn set_balance(env: &Env, account: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(account.clone()), &amount);
+}
+
+#[contract]
+pub struct VulnerableToken;
+
+#[contractimpl]
+impl VulnerableToken {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let current = get_balance(&env, &to);
+        let new_balance = current.checked_add(amount).expect("mint: balance overflow");
+        // ❌ No persistent().extend_ttl(...) after the write.
+        set_balance(&env, &to, new_balance);
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        // ❌ No persistent().extend_ttl(...) after the read.
+        get_balance(&env, &account)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+
+        let from_key = DataKey::Balance(from.clone());
+        let to_key = DataKey::Balance(to.clone());
+
+        let from_balance: i128 = env.storage().persistent().get(&from_key).unwrap_or(0);
+        let to_balance: i128 = env.storage().persistent().get(&to_key).unwrap_or(0);
+
+        let new_from = from_balance
+            .checked_sub(amount)
+            .expect("transfer: insufficient balance");
+        let new_to = to_balance
+            .checked_add(amount)
+            .expect("transfer: recipient balance overflow");
+
+        // ❌ No extend_ttl — entries expire and balances are lost.
+        env.storage().persistent().set(&from_key, &new_from);
+        env.storage().persistent().set(&to_key, &new_to);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{
+            storage::Persistent as _,
+            Address as _, Ledger as _,
+        },
+        Address, Env,
+    };
+
+    fn pin_contract_instance(env: &Env, contract_id: &Address) {
+        env.as_contract(contract_id, || {
+            let max_ttl = env.storage().max_ttl();
+            env.storage().instance().extend_ttl(max_ttl, max_ttl);
+        });
+    }
+
+    #[test]
+    fn test_transfer_works_normally() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, VulnerableToken);
+        let client = VulnerableTokenClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        env.mock_all_auths();
+
+        client.mint(&alice, &500);
+        client.mint(&bob, &100);
+        client.transfer(&alice, &bob, &200);
+
+        assert_eq!(client.balance(&alice), 300);
+        assert_eq!(client.balance(&bob), 300);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_balance_entry_expires_without_extend_ttl() {
+        let env = Env::default();
+        env.ledger().set_min_persistent_entry_ttl(5);
+        env.ledger().set_max_entry_ttl(20);
+
+        let contract_id = env.register_contract(None, VulnerableToken);
+        let client = VulnerableTokenClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        client.mint(&alice, &500);
+
+        // Keep the contract instance alive so this test isolates the balance
+        // entry expiry. The vulnerability is that the persistent balance slot
+        // itself is never renewed.
+        pin_contract_instance(&env, &contract_id);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                env.storage()
+                    .persistent()
+                    .get_ttl(&DataKey::Balance(alice.clone())),
+                4
+            );
+        });
+
+        env.ledger().set_sequence_number(6);
+
+        // After the entry TTL window passes, the balance record is archived.
+        // In this test harness, touching that archived key panics. On a real
+        // network the contract call would not execute at all once the entry has
+        // expired. Either way, after roughly `max_entry_expiration` / max-TTL
+        // ledgers, the user's funds become inaccessible if the contract never
+        // renews the persistent entry TTL.
+        client.balance(&alice);
+    }
+
+    #[test]
+    fn test_secure_transfer_refreshes_ttl() {
+        use crate::secure::SecureTokenClient;
+
+        let env = Env::default();
+        env.ledger().set_min_persistent_entry_ttl(5);
+        env.ledger().set_max_entry_ttl(20);
+
+        let contract_id = env.register_contract(None, secure::SecureToken);
+        let client = SecureTokenClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        env.mock_all_auths();
+
+        client.mint(&alice, &500);
+        client.mint(&bob, &100);
+        pin_contract_instance(&env, &contract_id);
+
+        env.ledger().set_sequence_number(16);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                env.storage()
+                    .persistent()
+                    .get_ttl(&DataKey::Balance(alice.clone())),
+                4
+            );
+            assert_eq!(
+                env.storage()
+                    .persistent()
+                    .get_ttl(&DataKey::Balance(bob.clone())),
+                4
+            );
+        });
+
+        client.transfer(&alice, &bob, &50);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                env.storage()
+                    .persistent()
+                    .get_ttl(&DataKey::Balance(alice.clone())),
+                20
+            );
+            assert_eq!(
+                env.storage()
+                    .persistent()
+                    .get_ttl(&DataKey::Balance(bob.clone())),
+                20
+            );
+        });
+
+        assert_eq!(client.balance(&alice), 450);
+        assert_eq!(client.balance(&bob), 150);
+    }
+}

--- a/vulnerable/missing_ttl/src/secure.rs
+++ b/vulnerable/missing_ttl/src/secure.rs
@@ -1,0 +1,68 @@
+//! SECURE mirror: refresh persistent-entry TTL after every balance read/write.
+//!
+//! This keeps active accounts alive by renewing their balance slots whenever
+//! they are accessed. The example focuses on persistent data entries; in a
+//! production contract you should also maintain contract instance/code TTL.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+fn extend_balance_ttl(env: &Env, key: &DataKey) {
+    let max_ttl = env.storage().max_ttl();
+    let threshold = max_ttl.saturating_sub(1);
+    env.storage()
+        .persistent()
+        .extend_ttl(key, threshold, max_ttl);
+}
+
+fn get_balance(env: &Env, account: &Address) -> i128 {
+    let key = DataKey::Balance(account.clone());
+    let balance: Option<i128> = env.storage().persistent().get(&key);
+
+    if balance.is_some() {
+        // ✅ Renew TTL after every successful read.
+        extend_balance_ttl(env, &key);
+    }
+
+    balance.unwrap_or(0)
+}
+
+fn set_balance(env: &Env, account: &Address, amount: i128) {
+    let key = DataKey::Balance(account.clone());
+    env.storage().persistent().set(&key, &amount);
+    // ✅ Renew TTL after every write.
+    extend_balance_ttl(env, &key);
+}
+
+#[contract]
+pub struct SecureToken;
+
+#[contractimpl]
+impl SecureToken {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let current = get_balance(&env, &to);
+        let new_balance = current.checked_add(amount).expect("mint: balance overflow");
+        set_balance(&env, &to, new_balance);
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        get_balance(&env, &account)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+
+        let from_balance = get_balance(&env, &from);
+        let to_balance = get_balance(&env, &to);
+
+        let new_from = from_balance
+            .checked_sub(amount)
+            .expect("transfer: insufficient balance");
+        let new_to = to_balance
+            .checked_add(amount)
+            .expect("transfer: recipient balance overflow");
+
+        set_balance(&env, &from, new_from);
+        set_balance(&env, &to, new_to);
+    }
+}

--- a/vulnerable/missing_ttl/test_snapshots/tests/test_balance_entry_expires_without_extend_ttl.1.json
+++ b/vulnerable/missing_ttl/test_snapshots/tests/test_balance_entry_expires_without_extend_ttl.1.json
@@ -1,0 +1,366 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 6,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 5,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 21,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          20
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          20
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "internal_error"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "[testing-only] Accessed contract data key key that has been archived. Important: this error may only appear in tests; in the real network contracts aren't called at all if any archived entry is accessed."
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "internal_error"
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating error to panic"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "internal_error"
+                }
+              }
+            ],
+            "data": {
+              "string": "caught error from function"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "internal_error"
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract call failed"
+                },
+                {
+                  "symbol": "balance"
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "storage": "internal_error"
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating error to panic"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/vulnerable/missing_ttl/test_snapshots/tests/test_secure_transfer_refreshes_ttl.1.json
+++ b/vulnerable/missing_ttl/test_snapshots/tests/test_secure_transfer_refreshes_ttl.1.json
@@ -1,0 +1,517 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 16,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 5,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 21,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 450
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          36
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 150
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          36
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          20
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          36
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          20
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 50
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 450
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 150
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/vulnerable/missing_ttl/test_snapshots/tests/test_transfer_works_normally.1.json
+++ b/vulnerable/missing_ttl/test_snapshots/tests/test_transfer_works_normally.1.json
@@ -1,0 +1,514 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "transfer",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 21,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 500
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 100
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "mint"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 200
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "transfer"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 300
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance"
+              }
+            ],
+            "data": {
+              "i128": {
+                "hi": 0,
+                "lo": 300
+              }
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/vulnerable/reentrancy/Cargo.toml
+++ b/vulnerable/reentrancy/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "reentrancy"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/reentrancy/src/lib.rs
+++ b/vulnerable/reentrancy/src/lib.rs
@@ -1,0 +1,203 @@
+//! VULNERABLE: Reentrancy via external callbacks before state update.
+//!
+//! A vault that notifies an external contract before reducing the user's
+//! balance. An attacker-controlled notifier can call back into `withdraw()`
+//! while the original user's balance is still intact.
+//!
+//! VULNERABILITY: `withdraw()` performs an external call before updating
+//! contract state, opening a reentrancy window.
+//!
+//! SECURE MIRROR: `secure::SecureReentrantVault` updates state before calling
+//! the external contract, blocking the reentrant callback.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Balance(Address),
+    Withdrawn(Address),
+}
+
+#[contracttype]
+pub enum NotifyDataKey {
+    Vault,
+    Notify,
+    Reenter,
+}
+
+#[contract]
+pub struct ReentrantVault;
+
+#[contractimpl]
+impl ReentrantVault {
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        let key = DataKey::Balance(user.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&key, &(current + amount));
+    }
+
+    pub fn withdraw(env: Env, user: Address, amount: i128, notify_id: Address) {
+        user.require_auth();
+
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(user.clone()))
+            .unwrap_or(0);
+
+        // ❌ External call BEFORE state update — reentrancy window.
+        NotifyContractClient::new(&env, &notify_id).on_withdraw(&user, &amount);
+
+        let new_balance = balance.checked_sub(amount).expect("insufficient funds");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(user.clone()), &new_balance);
+
+        let withdrawn_key = DataKey::Withdrawn(user.clone());
+        let withdrawn: i128 = env.storage().persistent().get(&withdrawn_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&withdrawn_key, &(withdrawn + amount));
+    }
+
+    pub fn get_balance(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(user))
+            .unwrap_or(0)
+    }
+
+    pub fn get_withdrawn(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Withdrawn(user))
+            .unwrap_or(0)
+    }
+}
+
+#[contract]
+pub struct NotifyContract;
+
+#[contractimpl]
+impl NotifyContract {
+    pub fn configure(env: Env, vault_id: Address, notify_id: Address, reenter: bool) {
+        env.storage()
+            .persistent()
+            .set(&NotifyDataKey::Vault, &vault_id);
+        env.storage()
+            .persistent()
+            .set(&NotifyDataKey::Notify, &notify_id);
+        env.storage()
+            .persistent()
+            .set(&NotifyDataKey::Reenter, &reenter);
+    }
+
+    pub fn on_withdraw(env: Env, user: Address, amount: i128) {
+        let reenter: bool = env
+            .storage()
+            .persistent()
+            .get(&NotifyDataKey::Reenter)
+            .unwrap_or(false);
+
+        if reenter {
+            env.storage()
+                .persistent()
+                .set(&NotifyDataKey::Reenter, &false);
+
+            let vault_id: Address = env
+                .storage()
+                .persistent()
+                .get(&NotifyDataKey::Vault)
+                .expect("vault not configured");
+            let notify_id: Address = env
+                .storage()
+                .persistent()
+                .get(&NotifyDataKey::Notify)
+                .expect("notify contract not configured");
+
+            ReentrantVaultClient::new(&env, &vault_id).withdraw(&user, &amount, &notify_id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (
+        Env,
+        Address,
+        ReentrantVaultClient<'static>,
+        Address,
+        NotifyContractClient<'static>,
+    ) {
+        let env = Env::default();
+        let vault_id = env.register_contract(None, ReentrantVault);
+        let vault_client = ReentrantVaultClient::new(&env, &vault_id);
+        let notify_id = env.register_contract(None, NotifyContract);
+        let notify_client = NotifyContractClient::new(&env, &notify_id);
+        (env, vault_id, vault_client, notify_id, notify_client)
+    }
+
+    #[test]
+    fn test_normal_withdraw_works() {
+        let (env, vault_id, vault_client, notify_id, notify_client) = setup();
+        env.mock_all_auths();
+
+        let alice = Address::generate(&env);
+        vault_client.deposit(&alice, &1000);
+        notify_client.configure(&vault_id, &notify_id, &false);
+
+        vault_client.withdraw(&alice, &400, &notify_id);
+
+        assert_eq!(vault_client.get_balance(&alice), 600);
+        assert_eq!(vault_client.get_withdrawn(&alice), 400);
+    }
+
+    #[test]
+    fn test_reentrant_withdraw_drains_more_than_balance() {
+        let (env, vault_id, vault_client, notify_id, notify_client) = setup();
+        env.mock_all_auths();
+
+        let alice = Address::generate(&env);
+        vault_client.deposit(&alice, &1000);
+        notify_client.configure(&vault_id, &notify_id, &true);
+
+        vault_client.withdraw(&alice, &1000, &notify_id);
+
+        assert_eq!(vault_client.get_balance(&alice), 0);
+        assert_eq!(vault_client.get_withdrawn(&alice), 2000);
+    }
+
+    #[test]
+    fn test_secure_reentrant_withdraw_blocks_the_attack() {
+        use crate::secure::SecureReentrantVaultClient;
+
+        let env = Env::default();
+        let vault_id = env.register_contract(None, secure::SecureReentrantVault);
+        let vault_client = SecureReentrantVaultClient::new(&env, &vault_id);
+        let notify_id = env.register_contract(None, NotifyContract);
+        let notify_client = NotifyContractClient::new(&env, &notify_id);
+
+        env.mock_all_auths();
+
+        let alice = Address::generate(&env);
+        vault_client.deposit(&alice, &1000);
+        notify_client.configure(&vault_id, &notify_id, &true);
+
+        let result = std::panic::catch_unwind(|| {
+            vault_client.withdraw(&alice, &1000, &notify_id);
+        });
+
+        assert!(result.is_err());
+        assert_eq!(vault_client.get_balance(&alice), 1000);
+        assert_eq!(vault_client.get_withdrawn(&alice), 0);
+    }
+}

--- a/vulnerable/reentrancy/src/secure.rs
+++ b/vulnerable/reentrancy/src/secure.rs
@@ -1,0 +1,56 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+use super::{DataKey, NotifyContractClient};
+
+#[contract]
+pub struct SecureReentrantVault;
+
+#[contractimpl]
+impl SecureReentrantVault {
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        let key = DataKey::Balance(user.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&key, &(current + amount));
+    }
+
+    pub fn withdraw(env: Env, user: Address, amount: i128, notify_id: Address) {
+        user.require_auth();
+
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(user.clone()))
+            .unwrap_or(0);
+        let new_balance = balance.checked_sub(amount).expect("insufficient funds");
+
+        // ✅ SECURE: Update state before making the external call.
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(user.clone()), &new_balance);
+
+        NotifyContractClient::new(&env, &notify_id).on_withdraw(&user, &amount);
+
+        let withdrawn_key = DataKey::Withdrawn(user.clone());
+        let withdrawn: i128 = env.storage().persistent().get(&withdrawn_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&withdrawn_key, &(withdrawn + amount));
+    }
+
+    pub fn get_balance(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(user))
+            .unwrap_or(0)
+    }
+
+    pub fn get_withdrawn(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Withdrawn(user))
+            .unwrap_or(0)
+    }
+}


### PR DESCRIPTION
## PR Description

### Summary
Added a new vulnerable crate demonstrating a Soroban reentrancy / checks-effects-interactions issue in reentrancy.

### What changed
- Added Cargo.toml
- Added lib.rs
- Added secure.rs
- Updated workspace Cargo.toml to include reentrancy

### Vulnerable scenario
- `ReentrantVault::withdraw()` calls an external `NotifyContract` before updating the caller’s balance
- Attacker-controlled `NotifyContract` re-enters `withdraw()` during the callback
- This allows draining more funds than the original balance

### Secure mirror
- `secure::SecureReentrantVault` updates the user balance before making the external notification call
- This blocks the reentrant callback and prevents the drain

### Tests included
- Normal withdraw succeeds
- Reentrant withdraw drains more than balance in vulnerable vault
- Secure withdraw blocks the attack and preserves balance

### Severity
- Critical: demonstrates a real reentrancy window in Soroban via callback-before-state-update behavior

Closes #9 