### PR TITLE
feat: add negative_transfer and string_admin vulnerable contracts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ members = [
     "vulnerable/unprotected_admin",
     "vulnerable/unsafe_storage",
     "vulnerable/reentrancy",
+    "vulnerable/negative_transfer",
+    "vulnerable/string_admin",
     "vulnerable/div_by_zero",
     "secure/secure_vault",
     "secure/protected_admin",

--- a/vulnerable/negative_transfer/Cargo.toml
+++ b/vulnerable/negative_transfer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "negative-transfer"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/negative_transfer/src/lib.rs
+++ b/vulnerable/negative_transfer/src/lib.rs
@@ -1,0 +1,174 @@
+//! VULNERABLE: Negative Transfer Amount Not Validated
+//!
+//! A token contract where `transfer()` accepts negative `amount` values.
+//! A negative amount reverses the transfer direction — the sender receives
+//! tokens from the recipient instead of sending them.
+//!
+//! VULNERABILITY: Missing `assert!(amount > 0)` guard before balance mutation.
+//! SECURE MIRROR: `SecureTokenContract` rejects `amount <= 0`.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    Balance(Address),
+}
+
+fn get_balance(env: &Env, account: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(account.clone()))
+        .unwrap_or(0)
+}
+
+fn set_balance(env: &Env, account: &Address, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Balance(account.clone()), &amount);
+}
+
+// ---------------------------------------------------------------------------
+// Vulnerable contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct TokenContract;
+
+#[contractimpl]
+impl TokenContract {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let current = get_balance(&env, &to);
+        set_balance(&env, &to, current + amount);
+    }
+
+    /// VULNERABLE: `amount` is never checked to be positive.
+    /// Passing a negative value causes `from` to gain tokens and `to` to lose them.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        // ❌ Missing: assert!(amount > 0, "amount must be positive");
+        set_balance(&env, &from, get_balance(&env, &from) - amount);
+        set_balance(&env, &to, get_balance(&env, &to) + amount);
+        env.events()
+            .publish((symbol_short!("transfer"),), (from, to, amount));
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        get_balance(&env, &account)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Secure mirror
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct SecureTokenContract;
+
+#[contractimpl]
+impl SecureTokenContract {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let current = get_balance(&env, &to);
+        set_balance(&env, &to, current + amount);
+    }
+
+    /// SECURE: rejects `amount <= 0` before touching balances.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "amount must be positive");
+        set_balance(&env, &from, get_balance(&env, &from) - amount);
+        set_balance(&env, &to, get_balance(&env, &to) + amount);
+        env.events()
+            .publish((symbol_short!("transfer"),), (from, to, amount));
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        get_balance(&env, &account)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    // --- Vulnerable contract tests ---
+
+    #[test]
+    fn test_positive_transfer_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint(&alice, &1000);
+        client.transfer(&alice, &bob, &400);
+
+        assert_eq!(client.balance(&alice), 600);
+        assert_eq!(client.balance(&bob), 400);
+    }
+
+    /// Demonstrates the vulnerability: a negative amount causes the sender
+    /// to receive tokens from the recipient instead of sending them.
+    #[test]
+    fn test_negative_amount_reverses_transfer() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, TokenContract);
+        let client = TokenContractClient::new(&env, &id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint(&alice, &500);
+        client.mint(&bob, &500);
+
+        // Alice "transfers" -200 to bob — she actually receives 200 from bob.
+        client.transfer(&alice, &bob, &-200);
+
+        assert_eq!(client.balance(&alice), 700); // gained 200
+        assert_eq!(client.balance(&bob), 300);   // lost 200
+    }
+
+    // --- Secure contract tests ---
+
+    #[test]
+    fn test_secure_rejects_negative_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureTokenContract);
+        let client = SecureTokenContractClient::new(&env, &id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint(&alice, &500);
+        client.mint(&bob, &500);
+
+        let result = client.try_transfer(&alice, &bob, &-200);
+        assert!(result.is_err());
+
+        // Balances unchanged
+        assert_eq!(client.balance(&alice), 500);
+        assert_eq!(client.balance(&bob), 500);
+    }
+
+    #[test]
+    fn test_secure_rejects_zero_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureTokenContract);
+        let client = SecureTokenContractClient::new(&env, &id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint(&alice, &500);
+
+        let result = client.try_transfer(&alice, &bob, &0);
+        assert!(result.is_err());
+    }
+}

--- a/vulnerable/string_admin/Cargo.toml
+++ b/vulnerable/string_admin/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "string-admin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/string_admin/src/lib.rs
+++ b/vulnerable/string_admin/src/lib.rs
@@ -1,0 +1,159 @@
+//! VULNERABLE: Admin Stored as String Instead of Address
+//!
+//! A contract that stores the admin as a `String` and authenticates callers
+//! with a plain `==` comparison. String comparison provides no cryptographic
+//! guarantee — any caller who knows (or guesses) the stored string value can
+//! pass the check without holding the corresponding private key.
+//!
+//! VULNERABILITY: `String` comparison instead of `Address::require_auth()`.
+//! SECURE MIRROR: `SecureConfigContract` stores admin as `Address` and calls
+//!                `admin.require_auth()`.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Config,
+}
+
+// ---------------------------------------------------------------------------
+// Vulnerable contract
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct ConfigContract;
+
+#[contractimpl]
+impl ConfigContract {
+    pub fn initialize(env: Env, admin: String) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// VULNERABLE: authenticates by comparing caller-supplied string to the
+    /// stored admin string. No cryptographic proof is required.
+    pub fn set_config(env: Env, caller: String, new_value: u32) {
+        let admin: String = env.storage().persistent().get(&DataKey::Admin).unwrap();
+        // ❌ String comparison — no cryptographic auth
+        if caller != admin {
+            panic!("not admin");
+        }
+        env.storage().persistent().set(&DataKey::Config, &new_value);
+    }
+
+    pub fn get_config(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Secure mirror
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct SecureConfigContract;
+
+#[contractimpl]
+impl SecureConfigContract {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// SECURE: retrieves the stored `Address` and calls `require_auth()`,
+    /// which enforces a cryptographic signature check.
+    pub fn set_config(env: Env, new_value: u32) {
+        let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Config, &new_value);
+    }
+
+    pub fn get_config(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    // --- Vulnerable contract tests ---
+
+    #[test]
+    fn test_correct_string_passes_check() {
+        let env = Env::default();
+        let id = env.register_contract(None, ConfigContract);
+        let client = ConfigContractClient::new(&env, &id);
+
+        let admin_str = String::from_str(&env, "admin-secret");
+        client.initialize(&admin_str);
+        client.set_config(&admin_str, &42);
+
+        assert_eq!(client.get_config(), 42);
+    }
+
+    /// Demonstrates the vulnerability: any caller who supplies the matching
+    /// string value passes the check — no private key required.
+    #[test]
+    fn test_any_caller_with_matching_string_passes() {
+        let env = Env::default();
+        let id = env.register_contract(None, ConfigContract);
+        let client = ConfigContractClient::new(&env, &id);
+
+        let admin_str = String::from_str(&env, "admin-secret");
+        client.initialize(&admin_str);
+
+        // An attacker who knows the string can call set_config without any key.
+        let attacker_str = String::from_str(&env, "admin-secret");
+        client.set_config(&attacker_str, &99);
+
+        assert_eq!(client.get_config(), 99);
+    }
+
+    // --- Secure contract tests ---
+
+    #[test]
+    fn test_secure_requires_address_auth() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureConfigContract);
+        let client = SecureConfigContractClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        client.set_config(&42);
+
+        assert_eq!(client.get_config(), 42);
+    }
+
+    #[test]
+    fn test_secure_rejects_without_auth() {
+        let env = Env::default();
+        // Deliberately do NOT mock auths — the call must fail.
+        let id = env.register_contract(None, SecureConfigContract);
+        let client = SecureConfigContractClient::new(&env, &id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+
+        let result = client.try_set_config(&42);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
Closes #31, closes #32

## Changes

**`vulnerable/negative_transfer`** (#31 — High severity)
- Vulnerable `transfer()` accepts negative `amount` values, reversing the transfer direction (sender receives tokens instead of sending)
- Secure mirror adds `assert!(amount > 0)` guard
- Tests: positive transfer works, negative amount reverses balances, secure version rejects ≤ 0

**`vulnerable/string_admin`** (#32 — High severity)
- Vulnerable contract stores admin as `String` and authenticates with `==` comparison — no cryptographic proof required
- Secure mirror stores admin as `Address` and calls `admin.require_auth()`
- Tests: correct string passes, any matching string passes (no real auth), secure version enforces auth

Both crates registered in workspace `Cargo.toml`.