### PR TITLE
feat: add vulnerable/zero_admin contract (#39)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "vulnerable/missing_auth",
+    "vulnerable/zero_admin",
     "vulnerable/missing_events",
     "vulnerable/missing_ttl",
     "vulnerable/timestamp_lock",

--- a/vulnerable/zero_admin/Cargo.toml
+++ b/vulnerable/zero_admin/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "zero-admin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/zero_admin/src/lib.rs
+++ b/vulnerable/zero_admin/src/lib.rs
@@ -1,0 +1,94 @@
+//! VULNERABLE: Missing Zero-Address Check on Initialize
+//!
+//! A contract where `initialize(admin)` stores the admin without validating
+//! that it is a real, non-default address. Passing the zero/default address
+//! permanently bricks all admin-gated functions.
+//!
+//! VULNERABILITY: `initialize` never asserts that `admin` is a valid non-zero
+//! address, so a caller can pass the Stellar zero address and lock the contract
+//! forever — no one can ever satisfy `require_auth` for that address.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Value,
+}
+
+#[contract]
+pub struct ZeroAdminContract;
+
+#[contractimpl]
+impl ZeroAdminContract {
+    /// VULNERABLE: accepts any address, including the zero/default address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        // ❌ Missing: assert admin != zero/default address
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Admin-gated function — permanently inaccessible if admin is zero.
+    pub fn set_value(env: Env, value: i128) {
+        let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Value, &value);
+    }
+
+    pub fn get_value(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::Value).unwrap_or(0)
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().persistent().get(&DataKey::Admin).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    // Stellar's "zero" account — all-zero public key, encodes to this strkey.
+    const ZERO_ADDR: &str = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+    fn setup() -> (Env, ZeroAdminContractClient<'static>) {
+        let env = Env::default();
+        let id = env.register_contract(None, ZeroAdminContract);
+        let client = ZeroAdminContractClient::new(&env, &id);
+        (env, client)
+    }
+
+    /// A valid admin address initializes correctly.
+    #[test]
+    fn test_valid_admin_initializes() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        client.initialize(&admin);
+        assert_eq!(client.get_admin(), admin);
+    }
+
+    /// Demonstrates the vulnerability: the zero address is silently accepted.
+    #[test]
+    fn test_zero_address_accepted_as_admin() {
+        let (env, client) = setup();
+        let zero = Address::from_string(&String::from_str(&env, ZERO_ADDR));
+        client.initialize(&zero);
+        assert_eq!(client.get_admin(), zero);
+    }
+
+    /// Demonstrates the consequence: admin functions are permanently inaccessible
+    /// because no real signer can provide auth for the zero address.
+    #[test]
+    #[should_panic]
+    fn test_admin_functions_permanently_inaccessible() {
+        let (env, client) = setup();
+        let zero = Address::from_string(&String::from_str(&env, ZERO_ADDR));
+        client.initialize(&zero);
+        // No auth can be provided for the zero address — panics.
+        client.set_value(&42);
+    }
+}


### PR DESCRIPTION
Missing zero-address check on initialize — passing the zero/default address as admin permanently bricks all admin-gated functions.

- New crate: vulnerable/zero_admin
- ZeroAdminContract: initialize stores admin without validation
- set_value is admin-gated and becomes permanently inaccessible
- 3 tests: valid init, zero address accepted, functions bricked
- Registered in workspace Cargo.toml    closes #39 