### PR TITLE
docs: add Mermaid architecture diagram and vulnerability pairing table

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,33 +238,72 @@ stellar contract invoke \
 
 ### Architecture diagram
 
+```mermaid
+flowchart TD
+    subgraph Stellar["Stellar Network (on-chain)"]
+        subgraph vuln["vulnerable/*"]
+            V1[missing_auth]
+            V2[unchecked_math]
+            V3[missing_ttl]
+            V4[unprotected_admin]
+            V5[unsafe_storage]
+        end
+
+        subgraph sec["secure/*"]
+            S1[secure_vault]
+            S2[protected_admin]
+        end
+
+        REG["registry\nsubmit_scan()\nget_scan()\nget_history()"]
+    end
+
+    CLI["soroban-guard-core\n(off-chain scanner CLI)"]
+
+    V1 -- mirrors --> S1
+    V2 -- mirrors --> S1
+    V4 -- mirrors --> S2
+    V5 -- mirrors --> S2
+
+    CLI -- "1. deploy & scan" --> vuln
+    CLI -- "2. submit_scan()\n(verified scanner only)" --> REG
+    CLI -- "3. get_scan() / get_history()" --> REG
 ```
-┌─────────────────────────────────────────────────────┐
-│                  Stellar Network                     │
-│                                                      │
-│  ┌─────────────┐      ┌──────────────────────────┐  │
-│  │  Vulnerable  │      │   Scan Result Registry   │  │
-│  │  Contracts   │─────▶│  (registry crate)        │  │
-│  │              │scan  │                          │  │
-│  │ missing_auth │      │  submit_scan()           │  │
-│  │ unchecked_   │      │  get_scan()              │  │
-│  │   math       │      │  get_history()           │  │
-│  │ unprotected_ │      └──────────────────────────┘  │
-│  │   admin      │               ▲                    │
-│  │ unsafe_      │               │ verified           │
-│  │   storage    │               │ scanners only      │
-│  └─────────────┘               │                    │
-│                                │                    │
-│  ┌─────────────┐               │                    │
-│  │   Secure     │               │                    │
-│  │  Contracts   │    ┌──────────────────────────┐   │
-│  │              │    │   soroban-guard-core CLI  │   │
-│  │ secure_vault │    │   (off-chain scanner)     │───┘
-│  │ protected_   │    └──────────────────────────┘
-│  │   admin      │
-│  └─────────────┘
-└─────────────────────────────────────────────────────┘
-```
+
+### Vulnerability ↔ secure-crate pairing
+
+| Vulnerability crate | Class | Secure mirror | Fix applied |
+|---|---|---|---|
+| `missing_auth` | Missing authorisation | `secure_vault` | `require_auth()` on transfer |
+| `unchecked_math` | Integer overflow | `secure_vault` | `checked_mul` / `checked_add` |
+| `missing_ttl` | Storage expiry | _(inline `secure.rs`)_ | `extend_ttl()` on every write |
+| `unprotected_admin` | Privilege escalation | `protected_admin` | Admin auth on `set_admin` / `upgrade` |
+| `unsafe_storage` | Unauthorised writes | `protected_admin` | Account auth on profile writes |
+| `key_collision` | Storage key clash | _(inline `secure.rs`)_ | Namespaced storage keys |
+| `admin_rugpull` | Admin rug-pull | _(inline `secure.rs`)_ | Two-step admin transfer |
+| `zero_deposit` | Zero-value deposit | _(inline `secure.rs`)_ | Guard `amount > 0` |
+| `dust_griefing` | Dust griefing | `secure/dust_griefing` | Minimum deposit threshold |
+| `instant_oracle` | Oracle manipulation | _(inline `secure.rs`)_ | TWAP / multi-source oracle |
+| `no_slippage` | Slippage | _(inline `secure.rs`)_ | `min_out` slippage guard |
+| `flash_loan_no_check` | Flash-loan re-entry | _(inline `secure.rs`)_ | Repayment check before return |
+| `leaky_events` | Sensitive data in events | _(inline `secure.rs`)_ | Emit only non-sensitive fields |
+| `scanner_impersonation` | Scanner spoofing | _(inline `secure.rs`)_ | On-chain scanner registry check |
+| `allowance_not_decremented` | Allowance bug | _(inline `secure.rs`)_ | Decrement allowance after spend |
+| `double_claim` | Double-claim | — | Claim flag in storage |
+| `div_by_zero` | Division by zero | — | Guard divisor `> 0` |
+| `negative_transfer` | Negative amount | — | Reject `amount < 0` |
+| `underflow_transfer` | Underflow | — | `checked_sub` |
+| `unprotected_burn` | Unprotected burn | `secure/secure_burn` | `require_auth()` on burn |
+| `unprotected_fee_withdraw` | Fee drain | `secure/protected_fee_withdraw` | Admin auth on fee withdrawal |
+| `unprotected_delete` | Storage wipe | — | Admin auth on delete |
+| `unprotected_emergency_withdraw` | Emergency drain | _(inline `secure.rs`)_ | Auth + time-lock |
+| `self_transfer` | Self-transfer | — | Reject `from == to` |
+| `reinit_attack` | Re-initialisation | — | Initialised flag guard |
+| `reentrancy` | Re-entrancy | _(inline `secure.rs`)_ | Checks-effects-interactions |
+| `zero_admin` | Zero address admin | — | Reject zero address |
+| `string_admin` | String-typed admin | — | Use `Address` type |
+| `zero_stake` | Zero-value stake | _(inline `secure.rs`)_ | Guard `amount > 0` |
+| `timestamp_lock` | Timestamp manipulation | `secure/sequence_lock` | Ledger sequence instead of timestamp |
+| `missing_events` | No events emitted | — | Emit structured events |
 
 ### Useful links
 


### PR DESCRIPTION
Closes #85

## Changes
- Replaced the ASCII architecture diagram with a Mermaid `flowchart TD` showing:
  - `vulnerable/*` → `secure/*` mirror relationships
  - Registry contract and its role (`submit_scan`, `get_scan`, `get_history`)
  - Scanner workflow: deploy & scan → submit_scan (verified only) → query
- Added full vulnerability ↔ secure-crate pairing table covering all 30 vulnerability classes

## Acceptance criteria
- [x] Diagram renders correctly in GitHub markdown (Mermaid is natively supported)
- [x] All existing vulnerable/secure pairs are represented
- [x] Scanner workflow is clear to a new contributor