### PR TITLE
ci: add cargo audit dependency vulnerability scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --all
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Run cargo audit
+        run: cargo audit --deny warnings

--- a/audit.toml
+++ b/audit.toml
@@ -1,0 +1,8 @@
+# audit.toml — cargo-audit configuration
+# Add entries here to ignore known false positives.
+# See: https://docs.rs/cargo-audit/latest/cargo_audit/
+
+[advisories]
+# Example:
+# ignore = ["RUSTSEC-2023-XXXX"]
+ignore = []


### PR DESCRIPTION
Closes #89

## Changes
- Created `.github/workflows/ci.yml` with two jobs:
  - `test` — runs `cargo test --all`
  - `audit` — installs `cargo-audit` and runs `cargo audit --deny warnings`
- Added `audit.toml` at repo root for suppressing known false positives

## Acceptance criteria
- [x] CI runs `cargo audit` on every PR
- [x] Known vulnerabilities in dependencies cause CI to fail (`--deny warnings`)
- [x] False positives can be ignored via `audit.toml`