### PR TITLE
feat: add replay_attack vulnerable/secure contract pair

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "vulnerable/unsafe_storage",
     "vulnerable/zero_deposit",
     "vulnerable/reentrancy",
+    "vulnerable/replay_attack",
     "vulnerable/dust_griefing",
     "vulnerable/negative_transfer",
     "vulnerable/string_admin",

--- a/vulnerable/replay_attack/Cargo.toml
+++ b/vulnerable/replay_attack/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "replay-attack"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/replay_attack/src/lib.rs
+++ b/vulnerable/replay_attack/src/lib.rs
@@ -1,0 +1,152 @@
+//! VULNERABLE: Replay Attack — Missing Nonce / Signature Reuse
+//!
+//! A contract that verifies an off-chain signature over a payload but never
+//! records that the signature was used. The same valid signature can be
+//! submitted repeatedly, executing the authorised action multiple times.
+//!
+//! VULNERABILITY: `execute_signed()` calls `verify_signature()` but stores no
+//! nonce, so an attacker can replay the same `(payload, signature)` pair
+//! indefinitely.
+//!
+//! SECURE MIRROR: `secure::SecureSignedExecutor` embeds a nonce inside the
+//! signed payload and marks each nonce as used after the first execution,
+//! causing any replay to panic.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Bytes, BytesN, Env};
+
+pub mod secure;
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Simulated off-chain signature: SHA-256 of the raw payload bytes.
+/// In production this would be an ed25519 signature; using a hash keeps the
+/// test environment simple while still demonstrating the replay pattern.
+pub fn verify_signature(env: &Env, payload: &Bytes, signature: &BytesN<32>) {
+    let expected = env.crypto().sha256(payload);
+    if expected != *signature {
+        panic!("invalid signature");
+    }
+}
+
+pub(crate) fn execute_payload(env: &Env, payload: &Bytes) {
+    env.events()
+        .publish((symbol_short!("executed"),), payload.clone());
+}
+
+// ---------------------------------------------------------------------------
+// Vulnerable contract
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+pub enum DataKey {
+    /// Tracks how many times a payload has been executed (for test assertions).
+    ExecCount(Bytes),
+    /// Nonce-used flag (only used by the secure contract).
+    NonceUsed(BytesN<32>),
+}
+
+#[contract]
+pub struct VulnerableSignedExecutor;
+
+#[contractimpl]
+impl VulnerableSignedExecutor {
+    /// VULNERABLE: verifies the signature but never records it was used.
+    /// The same `(payload, signature)` pair can be replayed indefinitely.
+    pub fn execute_signed(env: Env, payload: Bytes, signature: BytesN<32>) {
+        verify_signature(&env, &payload, &signature);
+
+        // ❌ Missing: assert nonce not already used, then mark as used.
+
+        let key = DataKey::ExecCount(payload.clone());
+        let count: u32 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(count + 1));
+
+        execute_payload(&env, &payload);
+    }
+
+    pub fn exec_count(env: Env, payload: Bytes) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ExecCount(payload))
+            .unwrap_or(0)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{Bytes, Env};
+
+    fn make_sig(env: &Env, payload: &Bytes) -> BytesN<32> {
+        env.crypto().sha256(payload)
+    }
+
+    // --- Vulnerable contract tests ---
+
+    #[test]
+    fn test_first_execution_succeeds() {
+        let env = Env::default();
+        let id = env.register_contract(None, VulnerableSignedExecutor);
+        let client = VulnerableSignedExecutorClient::new(&env, &id);
+
+        let payload = Bytes::from_slice(&env, b"pay:alice:100");
+        let sig = make_sig(&env, &payload);
+
+        client.execute_signed(&payload, &sig);
+        assert_eq!(client.exec_count(&payload), 1);
+    }
+
+    #[test]
+    fn test_replay_succeeds_on_vulnerable_contract() {
+        let env = Env::default();
+        let id = env.register_contract(None, VulnerableSignedExecutor);
+        let client = VulnerableSignedExecutorClient::new(&env, &id);
+
+        let payload = Bytes::from_slice(&env, b"pay:alice:100");
+        let sig = make_sig(&env, &payload);
+
+        // First execution
+        client.execute_signed(&payload, &sig);
+        // Replay with the exact same signature — succeeds (demonstrates vulnerability)
+        client.execute_signed(&payload, &sig);
+
+        assert_eq!(client.exec_count(&payload), 2);
+    }
+
+    // --- Secure contract tests ---
+
+    #[test]
+    fn test_secure_first_execution_succeeds() {
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureSignedExecutor);
+        let client = secure::SecureSignedExecutorClient::new(&env, &id);
+
+        let payload = Bytes::from_slice(&env, b"pay:alice:100");
+        let sig = make_sig(&env, &payload);
+
+        client.execute_signed(&payload, &sig);
+        assert_eq!(client.exec_count(&payload), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "already used")]
+    fn test_secure_replay_is_rejected() {
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureSignedExecutor);
+        let client = secure::SecureSignedExecutorClient::new(&env, &id);
+
+        let payload = Bytes::from_slice(&env, b"pay:alice:100");
+        let sig = make_sig(&env, &payload);
+
+        client.execute_signed(&payload, &sig);
+        // Replay — must panic
+        client.execute_signed(&payload, &sig);
+    }
+}

--- a/vulnerable/replay_attack/src/secure.rs
+++ b/vulnerable/replay_attack/src/secure.rs
@@ -1,0 +1,40 @@
+//! SECURE: Replay Attack — Nonce Tracking
+//!
+//! The signature hash is used as the nonce key. After the first successful
+//! execution the nonce is marked as used; any replay panics immediately.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Bytes, BytesN, Env};
+use super::{DataKey, execute_payload, verify_signature};
+
+#[contract]
+pub struct SecureSignedExecutor;
+
+#[contractimpl]
+impl SecureSignedExecutor {
+    /// SECURE: verifies the signature, asserts the nonce has not been used,
+    /// marks it as used, then executes the payload.
+    pub fn execute_signed(env: Env, payload: Bytes, signature: BytesN<32>) {
+        verify_signature(&env, &payload, &signature);
+
+        // ✅ Reject replays: the signature hash serves as the nonce.
+        let nonce_key = DataKey::NonceUsed(signature.clone());
+        if env.storage().persistent().get::<_, bool>(&nonce_key).unwrap_or(false) {
+            panic!("already used");
+        }
+        env.storage().persistent().set(&nonce_key, &true);
+
+        let count_key = DataKey::ExecCount(payload.clone());
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        env.storage().persistent().set(&count_key, &(count + 1));
+
+        execute_payload(&env, &payload);
+    }
+
+    pub fn exec_count(env: Env, payload: Bytes) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ExecCount(payload))
+            .unwrap_or(0)
+    }
+}


### PR DESCRIPTION
Closes #56

---

## Summary

Adds a new `vulnerable/replay_attack` crate demonstrating the **signature replay attack** vulnerability class.

## Vulnerability

A contract that verifies an off-chain signature without recording it as used allows the same `(payload, signature)` pair to be submitted repeatedly, executing the authorised action multiple times.

**Severity:** Critical

## Contracts

| Contract | Crate | Description |
|---|---|---|
| `VulnerableSignedExecutor` | `vulnerable/replay_attack` | Verifies signature but stores no nonce — replay succeeds |
| `SecureSignedExecutor` | `vulnerable/replay_attack::secure` | Marks signature hash as used after first execution — replay panics |

## Vulnerable pattern

```rust
pub fn execute_signed(env: Env, payload: Bytes, signature: BytesN<32>) {
    verify_signature(&env, &payload, &signature);
    // ❌ Missing: assert nonce not already used, then mark as used
    execute_payload(&env, &payload);
}
```

## Secure fix

```rust
pub fn execute_signed(env: Env, payload: Bytes, signature: BytesN<32>) {
    verify_signature(&env, &payload, &signature);
    // ✅ Reject replays: signature hash serves as the nonce
    let nonce_key = DataKey::NonceUsed(signature.clone());
    if env.storage().persistent().get::<_, bool>(&nonce_key).unwrap_or(false) {
        panic!("already used");
    }
    env.storage().persistent().set(&nonce_key, &true);
    execute_payload(&env, &payload);
}
```

## Tests

- `test_first_execution_succeeds` — valid signature executes successfully
- `test_replay_succeeds_on_vulnerable_contract` — same signature replayed, exec count = 2 (demonstrates vulnerability)
- `test_secure_first_execution_succeeds` — secure contract executes on first call
- `test_secure_replay_is_rejected` — secure contract panics with `already used` on replay