### PR TITLE
feat: add secure_token canonical reference implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "secure/protected_admin",
     "secure/secure_transfer",
     "secure/secure_burn",
+    "secure/secure_token",
     "registry",
 ]
 

--- a/secure/secure_token/Cargo.toml
+++ b/secure/secure_token/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "secure-token"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/secure/secure_token/src/lib.rs
+++ b/secure/secure_token/src/lib.rs
@@ -1,0 +1,199 @@
+//! SECURE: Canonical Secure Token
+//!
+//! Reference implementation combining all token security patterns:
+//! - Admin-gated mint/burn with `admin.require_auth()`
+//! - `from.require_auth()` on transfer
+//! - Checked arithmetic on every balance mutation
+//! - Self-transfer guard
+//! - Events emitted on every state change
+//! - Total supply tracked on mint/burn
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Balance(Address),
+    TotalSupply,
+}
+
+#[contract]
+pub struct SecureToken;
+
+#[contractimpl]
+impl SecureToken {
+    /// One-time initialisation — sets the admin.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Mint `amount` tokens to `to`. Requires admin auth.
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(to.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(to.clone()), &bal.checked_add(amount).expect("overflow"));
+
+        let supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalSupply, &supply.checked_add(amount).expect("overflow"));
+
+        env.events().publish((symbol_short!("mint"),), (to, amount));
+    }
+
+    /// Burn `amount` tokens from `from`. Requires `from` auth.
+    pub fn burn(env: Env, from: Address, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        from.require_auth();
+
+        let bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(from.clone()))
+            .unwrap_or(0);
+        let new_bal = bal.checked_sub(amount).expect("insufficient balance");
+        assert!(new_bal >= 0, "insufficient balance");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(from.clone()), &new_bal);
+
+        let supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalSupply, &supply.checked_sub(amount).expect("supply underflow"));
+
+        env.events().publish((symbol_short!("burn"),), (from, amount));
+    }
+
+    /// Transfer `amount` from `from` to `to`. Requires `from` auth.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        assert!(from != to, "self-transfer not allowed");
+        from.require_auth();
+
+        let from_bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(from.clone()))
+            .unwrap_or(0);
+        let to_bal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(to.clone()))
+            .unwrap_or(0);
+
+        let new_from = from_bal.checked_sub(amount).expect("insufficient balance");
+        assert!(new_from >= 0, "insufficient balance");
+        let new_to = to_bal.checked_add(amount).expect("overflow");
+
+        env.storage().persistent().set(&DataKey::Balance(from.clone()), &new_from);
+        env.storage().persistent().set(&DataKey::Balance(to.clone()), &new_to);
+
+        env.events().publish((symbol_short!("transfer"),), (from, to, amount));
+    }
+
+    pub fn balance(env: Env, account: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(account))
+            .unwrap_or(0)
+    }
+
+    pub fn total_supply(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, Address, SecureTokenClient<'static>) {
+        let env = Env::default();
+        let id = env.register_contract(None, SecureToken);
+        let client = SecureTokenClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        (env, admin, client)
+    }
+
+    #[test]
+    fn test_admin_mint_user_transfer_user_burn() {
+        let (env, _admin, client) = setup();
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.mint(&alice, &1000);
+        assert_eq!(client.balance(&alice), 1000);
+        assert_eq!(client.total_supply(), 1000);
+
+        client.transfer(&alice, &bob, &400);
+        assert_eq!(client.balance(&alice), 600);
+        assert_eq!(client.balance(&bob), 400);
+
+        client.burn(&bob, &100);
+        assert_eq!(client.balance(&bob), 300);
+        assert_eq!(client.total_supply(), 900);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_non_admin_cannot_mint() {
+        let (env, _admin, client) = setup();
+        let attacker = Address::generate(&env);
+        // mock_all_auths not called for attacker — require_auth on admin will fail
+        client.mint(&attacker, &1000);
+    }
+
+    #[test]
+    #[should_panic(expected = "self-transfer not allowed")]
+    fn test_self_transfer_rejected() {
+        let (env, _admin, client) = setup();
+        let alice = Address::generate(&env);
+        env.mock_all_auths();
+        client.mint(&alice, &500);
+        client.transfer(&alice, &alice, &100);
+    }
+
+    #[test]
+    #[should_panic(expected = "overflow")]
+    fn test_mint_overflow_panics() {
+        let (env, _admin, client) = setup();
+        let alice = Address::generate(&env);
+        env.mock_all_auths();
+        client.mint(&alice, &i128::MAX);
+        // Second mint pushes balance past i128::MAX
+        client.mint(&alice, &1);
+    }
+}


### PR DESCRIPTION
Closes #70

---

## Summary

Adds `secure/secure_token` — a canonical reference implementation combining all token security patterns in one contract.

## What's included

| Method | Auth | Guards |
|---|---|---|
| `initialize(admin)` | — | panics if already initialized |
| `mint(to, amount)` | `admin.require_auth()` | `checked_add` on balance + total supply |
| `burn(from, amount)` | `from.require_auth()` | `checked_sub`, asserts balance ≥ 0 |
| `transfer(from, to, amount)` | `from.require_auth()` | `from != to` guard, `checked_sub`/`checked_add` |

Events emitted on every state change (`mint`, `burn`, `transfer`). Total supply tracked and updated on mint/burn.

## Tests

- `test_admin_mint_user_transfer_user_burn` — full happy path, supply tracked correctly
- `test_non_admin_cannot_mint` — `#[should_panic]` without admin auth
- `test_self_transfer_rejected` — `#[should_panic(expected = "self-transfer not allowed")]`
- `test_mint_overflow_panics` — mints `i128::MAX` then `+1`, `#[should_panic(expected = "overflow")]`