### PR TITLE
chore: standardize Cargo.toml metadata across all crates

### DIFF
--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -2,6 +2,9 @@
 name = "registry"
 version = "0.1.0"
 edition = "2021"
+description = "On-chain scan result registry for Soroban Guard findings"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/dust_griefing/Cargo.toml
+++ b/secure/dust_griefing/Cargo.toml
@@ -2,6 +2,9 @@
 name = "secure-dust-griefing"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban contract demonstrating dust-griefing mitigation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/protected_admin/Cargo.toml
+++ b/secure/protected_admin/Cargo.toml
@@ -2,6 +2,9 @@
 name = "protected-admin"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban contract with admin auth on set_admin, upgrade, and profile writes"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/protected_fee_withdraw/Cargo.toml
+++ b/secure/protected_fee_withdraw/Cargo.toml
@@ -2,6 +2,9 @@
 name = "protected-fee-withdraw"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban contract with protected fee withdrawal"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/secure_burn/Cargo.toml
+++ b/secure/secure_burn/Cargo.toml
@@ -2,6 +2,9 @@
 name = "secure_burn"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban contract with authenticated token burn"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 publish = false
 
 [lib]

--- a/secure/secure_multisig/Cargo.toml
+++ b/secure/secure_multisig/Cargo.toml
@@ -2,6 +2,9 @@
 name = "secure-multisig"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban multisig contract requiring threshold approvals"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/secure_pausable/Cargo.toml
+++ b/secure/secure_pausable/Cargo.toml
@@ -2,6 +2,9 @@
 name = "secure-pausable"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban contract with admin-controlled pause mechanism"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/secure_token/Cargo.toml
+++ b/secure/secure_token/Cargo.toml
@@ -2,6 +2,9 @@
 name = "secure-token"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban token contract with auth and checked arithmetic"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/secure_transfer/Cargo.toml
+++ b/secure/secure_transfer/Cargo.toml
@@ -2,6 +2,9 @@
 name = "secure-transfer"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban transfer contract with full auth and validation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/secure_vault/Cargo.toml
+++ b/secure/secure_vault/Cargo.toml
@@ -2,6 +2,9 @@
 name = "secure-vault"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban vault with require_auth on transfer and checked arithmetic"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/secure/sequence_lock/Cargo.toml
+++ b/secure/sequence_lock/Cargo.toml
@@ -2,6 +2,9 @@
 name = "sequence-lock"
 version = "0.1.0"
 edition = "2021"
+description = "Secure Soroban contract using sequence numbers to prevent replay attacks"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/admin_rugpull/Cargo.toml
+++ b/vulnerable/admin_rugpull/Cargo.toml
@@ -2,6 +2,9 @@
 name = "admin-rugpull"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating admin rugpull via unprotected upgrade"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/allowance_not_decremented/Cargo.toml
+++ b/vulnerable/allowance_not_decremented/Cargo.toml
@@ -2,6 +2,9 @@
 name = "allowance-not-decremented"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban token contract where allowance is never decremented after transfer"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/call_depth/Cargo.toml
+++ b/vulnerable/call_depth/Cargo.toml
@@ -2,6 +2,9 @@
 name = "call-depth"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating unbounded call-depth exploitation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/div_by_zero/Cargo.toml
+++ b/vulnerable/div_by_zero/Cargo.toml
@@ -2,6 +2,9 @@
 name = "div-by-zero"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating unguarded division by zero"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/double_claim/Cargo.toml
+++ b/vulnerable/double_claim/Cargo.toml
@@ -2,6 +2,9 @@
 name = "double-claim"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating double-claim of rewards"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/dust_griefing/Cargo.toml
+++ b/vulnerable/dust_griefing/Cargo.toml
@@ -2,6 +2,9 @@
 name = "dust-griefing"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating dust-griefing attack vector"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/flash_loan_no_check/Cargo.toml
+++ b/vulnerable/flash_loan_no_check/Cargo.toml
@@ -2,6 +2,9 @@
 name = "flash-loan-no-check"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating flash loan with no repayment check"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/instant_oracle/Cargo.toml
+++ b/vulnerable/instant_oracle/Cargo.toml
@@ -2,6 +2,9 @@
 name = "instant-oracle"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating instant/manipulable oracle price reads"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/key_collision/Cargo.toml
+++ b/vulnerable/key_collision/Cargo.toml
@@ -2,6 +2,9 @@
 name = "key-collision"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating storage key collision"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/leaky_events/Cargo.toml
+++ b/vulnerable/leaky_events/Cargo.toml
@@ -2,6 +2,9 @@
 name = "leaky-events"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating sensitive data leaked via events"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/missing_auth/Cargo.toml
+++ b/vulnerable/missing_auth/Cargo.toml
@@ -2,6 +2,9 @@
 name = "missing-auth"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban token contract demonstrating missing require_auth on transfer"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/missing_events/Cargo.toml
+++ b/vulnerable/missing_events/Cargo.toml
@@ -2,6 +2,9 @@
 name = "missing-events"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating absence of required audit events"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/missing_ttl/Cargo.toml
+++ b/vulnerable/missing_ttl/Cargo.toml
@@ -2,6 +2,9 @@
 name = "missing-ttl"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban token contract where persistent storage TTL is never extended"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/negative_transfer/Cargo.toml
+++ b/vulnerable/negative_transfer/Cargo.toml
@@ -2,6 +2,9 @@
 name = "negative-transfer"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating negative transfer amount exploit"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/no_slippage/Cargo.toml
+++ b/vulnerable/no_slippage/Cargo.toml
@@ -2,6 +2,9 @@
 name = "no-slippage"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban AMM contract with no slippage protection"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/reentrancy/Cargo.toml
+++ b/vulnerable/reentrancy/Cargo.toml
@@ -2,6 +2,9 @@
 name = "reentrancy"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating reentrancy attack pattern"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/reinit_attack/Cargo.toml
+++ b/vulnerable/reinit_attack/Cargo.toml
@@ -2,6 +2,9 @@
 name = "reinit-attack"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating reinitialization attack"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/replay_attack/Cargo.toml
+++ b/vulnerable/replay_attack/Cargo.toml
@@ -2,6 +2,9 @@
 name = "replay-attack"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating replay attack via missing nonce"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/scanner_impersonation/Cargo.toml
+++ b/vulnerable/scanner_impersonation/Cargo.toml
@@ -2,6 +2,9 @@
 name = "scanner-impersonation"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating scanner identity impersonation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/self_transfer/Cargo.toml
+++ b/vulnerable/self_transfer/Cargo.toml
@@ -2,6 +2,9 @@
 name = "self-transfer"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating self-transfer balance manipulation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/sensitive_storage/Cargo.toml
+++ b/vulnerable/sensitive_storage/Cargo.toml
@@ -2,6 +2,9 @@
 name = "sensitive-storage"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract storing sensitive data in public storage"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/stale_oracle/Cargo.toml
+++ b/vulnerable/stale_oracle/Cargo.toml
@@ -2,6 +2,9 @@
 name = "stale-oracle"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating stale oracle price acceptance"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/string_admin/Cargo.toml
+++ b/vulnerable/string_admin/Cargo.toml
@@ -2,6 +2,9 @@
 name = "string-admin"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract using a plain string as an admin identifier"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/timestamp_lock/Cargo.toml
+++ b/vulnerable/timestamp_lock/Cargo.toml
@@ -2,6 +2,9 @@
 name = "timestamp-lock"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating timestamp-based lock bypass"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unbounded_storage/Cargo.toml
+++ b/vulnerable/unbounded_storage/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unbounded-storage"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating unbounded storage growth"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/uncapped_rate/Cargo.toml
+++ b/vulnerable/uncapped_rate/Cargo.toml
@@ -2,6 +2,9 @@
 name = "uncapped-rate"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract with uncapped interest/reward rate"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unchecked_math/Cargo.toml
+++ b/vulnerable/unchecked_math/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unchecked-math"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban staking contract with unchecked arithmetic overflow"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/underflow_transfer/Cargo.toml
+++ b/vulnerable/underflow_transfer/Cargo.toml
@@ -2,6 +2,9 @@
 name = "underflow-transfer"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating integer underflow on transfer"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unprotected_admin/Cargo.toml
+++ b/vulnerable/unprotected_admin/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unprotected-admin"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban escrow contract with open set_admin and upgrade functions"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unprotected_burn/Cargo.toml
+++ b/vulnerable/unprotected_burn/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unprotected_burn"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract allowing anyone to burn tokens"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 publish = false
 
 [lib]

--- a/vulnerable/unprotected_delete/Cargo.toml
+++ b/vulnerable/unprotected_delete/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unprotected-delete"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract allowing anyone to delete storage entries"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unprotected_emergency_withdraw/Cargo.toml
+++ b/vulnerable/unprotected_emergency_withdraw/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unprotected-emergency-withdraw"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract with unprotected emergency withdrawal"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unprotected_fee_withdraw/Cargo.toml
+++ b/vulnerable/unprotected_fee_withdraw/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unprotected-fee-withdraw"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract with unprotected fee withdrawal"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unprotected_mint/Cargo.toml
+++ b/vulnerable/unprotected_mint/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unprotected-mint"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract allowing anyone to mint tokens"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unsafe_cast/Cargo.toml
+++ b/vulnerable/unsafe_cast/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unsafe-cast"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract demonstrating unsafe integer casting"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/unsafe_storage/Cargo.toml
+++ b/vulnerable/unsafe_storage/Cargo.toml
@@ -2,6 +2,9 @@
 name = "unsafe-storage"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban KYC registry allowing writes to any account's storage"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/zero_admin/Cargo.toml
+++ b/vulnerable/zero_admin/Cargo.toml
@@ -2,6 +2,9 @@
 name = "zero-admin"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract that accepts a zero address as admin"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/zero_deposit/Cargo.toml
+++ b/vulnerable/zero_deposit/Cargo.toml
@@ -2,6 +2,9 @@
 name = "zero-deposit"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban contract that accepts zero-value deposits"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]

--- a/vulnerable/zero_stake/Cargo.toml
+++ b/vulnerable/zero_stake/Cargo.toml
@@ -2,6 +2,9 @@
 name = "zero-stake"
 version = "0.1.0"
 edition = "2021"
+description = "Vulnerable Soroban staking contract that accepts zero-value stakes"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary

Adds the missing standard metadata fields to every crate `Cargo.toml` in the workspace (50 crates total).

**Fields added to each crate:**
- `description` — one-line summary of what the crate demonstrates
- `license = "MIT"`
- `repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"`

`version = "0.1.0"` and `edition = "2021"` were already present on all crates.

## Crates updated

All crates under `registry/`, `vulnerable/`, and `secure/`.

## Testing

`cargo metadata --no-deps` shows no missing field warnings after this change.

Closes #98