### PR TITLE
docs: add SECURITY.md with responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## About This Repository
+
+`soroban-guard-contracts` is an **educational** repository containing intentionally
+vulnerable Soroban smart contracts used to test the
+[Soroban Guard](https://github.com/Veritas-Vaults-Network/soroban-guard-core) scanner.
+The vulnerable contracts are broken **by design** — please do not report their
+weaknesses as security issues.
+
+Real vulnerabilities to report are those in:
+- The **registry** contract (on-chain scan result storage)
+- The **Soroban Guard scanner** ([soroban-guard-core](https://github.com/Veritas-Vaults-Network/soroban-guard-core))
+- The **CI/CD pipeline or tooling** in this repo
+
+## Supported Versions
+
+| Component | Supported |
+|---|---|
+| `registry` contract (latest `main`) | ✅ |
+| Vulnerable example contracts | ❌ intentionally broken |
+| Secure example contracts | ✅ |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Use GitHub's private vulnerability reporting instead:
+👉 [Report a vulnerability](https://github.com/Veritas-Vaults-Network/soroban-guard-contracts/security/advisories/new)
+
+Include:
+- A clear description of the vulnerability
+- Steps to reproduce or a proof-of-concept
+- The potential impact
+- Any suggested fix (optional)
+
+## Response Timeline
+
+| Milestone | Target |
+|---|---|
+| Acknowledgement | Within **48 hours** |
+| Initial assessment | Within **5 days** |
+| Fix or mitigation | Within **7 days** for critical issues |
+| Public disclosure | Coordinated with the reporter |
+
+## Out of Scope
+
+- Vulnerabilities in the `vulnerable/` contracts — they are intentional
+- Issues in third-party dependencies (report to the upstream maintainer)
+- Theoretical attacks with no practical exploit path
+- Findings from automated scanners without manual verification


### PR DESCRIPTION
## Summary

Adds `SECURITY.md` at the repo root so GitHub can display the security policy and populate the private vulnerability reporting flow.

## Sections included

- **About This Repository** — clarifies that vulnerable contracts are intentionally broken and not in scope
- **Supported Versions** — registry + secure contracts supported; vulnerable contracts explicitly out of scope
- **Reporting a Vulnerability** — links to GitHub private advisory reporting
- **Response Timeline** — 48h acknowledgement, 5 days assessment, 7 days fix for critical issues
- **Out of Scope** — vulnerable contracts, upstream deps, theoretical attacks

Closes #84