### PR TITLE
Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "vulnerable/unsafe_cast",
     "secure/secure_vault",
     "secure/protected_admin",
+    "secure/secure_airdrop",
     "secure/protected_fee_withdraw",
     "secure/secure_burn",
     "secure/secure_token",

--- a/README.md
+++ b/README.md
@@ -45,11 +45,46 @@ soroban-guard-contracts/
 
 | Crate | Context | Vulnerability |
 |---|---|---|
-| `missing_auth` | Token contract | `transfer()` mutates balances without `require_auth()` |
-| `missing_ttl` | Token contract | Persistent balances expire because the contract never calls `extend_ttl()` |
-| `unchecked_math` | Staking contract | Reward calc uses raw `*` on `u64` — overflows silently |
-| `unprotected_admin` | Escrow contract | `set_admin()` and `upgrade()` have no caller check |
-| `unsafe_storage` | KYC registry | Any caller can write to any account's storage slot |
+| [`missing_auth`](./vulnerable/missing_auth/README.md) | Token contract | `transfer()` mutates balances without `require_auth()` |
+| [`missing_ttl`](./vulnerable/missing_ttl/README.md) | Token contract | Persistent balances expire because the contract never calls `extend_ttl()` |
+| [`unchecked_math`](./vulnerable/unchecked_math/README.md) | Staking contract | Reward calc uses raw `*` on `u64` — overflows silently |
+| [`unprotected_admin`](./vulnerable/unprotected_admin/README.md) | Escrow contract | `set_admin()` and `upgrade()` have no caller check |
+| [`unsafe_storage`](./vulnerable/unsafe_storage/README.md) | KYC registry | Any caller can write to any account's storage slot |
+| [`admin_rugpull`](./vulnerable/admin_rugpull/README.md) | Admin contract | Single-step admin transfer with no acceptance confirmation |
+| [`allowance_not_decremented`](./vulnerable/allowance_not_decremented/README.md) | Token contract | Allowance not reduced after `transfer_from` |
+| [`call_depth`](./vulnerable/call_depth/README.md) | Cross-contract | Unbounded recursive calls exhaust the call stack |
+| [`div_by_zero`](./vulnerable/div_by_zero/README.md) | Fee contract | Division by zero when pool or supply is empty |
+| [`double_claim`](./vulnerable/double_claim/README.md) | Staking contract | Reward window never resets — same period claimed repeatedly |
+| [`dust_griefing`](./vulnerable/dust_griefing/README.md) | Vault contract | No minimum deposit — storage bloated with dust entries |
+| [`flash_loan_no_check`](./vulnerable/flash_loan_no_check/README.md) | Lending contract | Flash loan repayment not verified before returning |
+| [`instant_oracle`](./vulnerable/instant_oracle/README.md) | DEX contract | Single-block oracle price is manipulable via flash loan |
+| [`key_collision`](./vulnerable/key_collision/README.md) | Token contract | Different data types share the same storage key |
+| [`leaky_events`](./vulnerable/leaky_events/README.md) | Registry contract | Sensitive data emitted in public contract events |
+| [`missing_events`](./vulnerable/missing_events/README.md) | Token contract | No events emitted — off-chain indexers are blind |
+| [`negative_transfer`](./vulnerable/negative_transfer/README.md) | Token contract | Negative amount reverses transfer direction |
+| [`no_slippage`](./vulnerable/no_slippage/README.md) | DEX contract | No `min_out` guard — sandwich attacks extract value |
+| [`reentrancy`](./vulnerable/reentrancy/README.md) | Vault contract | External call before state update enables re-entrancy |
+| [`reinit_attack`](./vulnerable/reinit_attack/README.md) | Any contract | `initialize()` callable multiple times — admin replaced |
+| [`replay_attack`](./vulnerable/replay_attack/README.md) | Signature contract | Signed messages not invalidated — replayable indefinitely |
+| [`scanner_impersonation`](./vulnerable/scanner_impersonation/README.md) | Registry contract | Scanner address not verified against approved list |
+| [`self_transfer`](./vulnerable/self_transfer/README.md) | Token contract | `from == to` corrupts balance accounting |
+| [`sensitive_storage`](./vulnerable/sensitive_storage/README.md) | Registry contract | Secrets stored in publicly readable contract storage |
+| [`stale_oracle`](./vulnerable/stale_oracle/README.md) | DEX contract | Oracle price used without staleness check |
+| [`string_admin`](./vulnerable/string_admin/README.md) | Admin contract | Admin stored as `String` — bypasses `require_auth` |
+| [`timestamp_lock`](./vulnerable/timestamp_lock/README.md) | Vault contract | Time-lock uses manipulable `ledger().timestamp()` |
+| [`unbounded_storage`](./vulnerable/unbounded_storage/README.md) | Registry contract | Unbounded collection growth exhausts storage |
+| [`uncapped_rate`](./vulnerable/uncapped_rate/README.md) | Staking contract | Reward rate has no upper bound — pool drainable |
+| [`unchecked_math`](./vulnerable/unchecked_math/README.md) | Staking contract | Raw arithmetic overflows silently |
+| [`underflow_transfer`](./vulnerable/underflow_transfer/README.md) | Token contract | Unchecked subtraction wraps balance to `u64::MAX` |
+| [`unprotected_burn`](./vulnerable/unprotected_burn/README.md) | Token contract | `burn()` callable by anyone — destroys any account's tokens |
+| [`unprotected_delete`](./vulnerable/unprotected_delete/README.md) | Any contract | Storage wipe callable without admin auth |
+| [`unprotected_emergency_withdraw`](./vulnerable/unprotected_emergency_withdraw/README.md) | Vault contract | Emergency drain callable by any address |
+| [`unprotected_fee_withdraw`](./vulnerable/unprotected_fee_withdraw/README.md) | DEX contract | Fee withdrawal open to any caller |
+| [`unprotected_mint`](./vulnerable/unprotected_mint/README.md) | Token contract | `mint()` callable by anyone — unlimited supply inflation |
+| [`unsafe_cast`](./vulnerable/unsafe_cast/README.md) | Token contract | Integer cast truncates or wraps silently |
+| [`zero_admin`](./vulnerable/zero_admin/README.md) | Admin contract | Admin set to zero address — contract permanently locked |
+| [`zero_deposit`](./vulnerable/zero_deposit/README.md) | Vault contract | Zero-value deposit accepted — storage griefing |
+| [`zero_stake`](./vulnerable/zero_stake/README.md) | Staking contract | Zero-value stake accepted — division-by-zero risk |
 
 ### Secure
 

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -1,0 +1,185 @@
+# Threat Model — soroban-guard-contracts
+
+This document describes the security model for the contracts in this repository.
+It is intended for security reviewers, auditors, and contributors.
+
+---
+
+## Actors
+
+| Actor     | Trust Level | Capabilities |
+|-----------|-------------|--------------|
+| Admin     | High        | Upgrade contracts, rotate keys, add/remove scanners, dispute scans, set parameters |
+| Scanner   | Medium      | Submit scan results for registered contracts (must be approved by admin) |
+| Staker    | Low         | Stake tokens, unstake, claim rewards — only over their own funds |
+| Attacker  | None        | Controls one or more addresses; assumed to call any public function with arbitrary inputs |
+
+---
+
+## Assets at Risk
+
+| Asset | Location | Impact if compromised |
+|-------|----------|-----------------------|
+| Token balances | vault / staking contracts | Direct financial loss |
+| Admin private key | off-chain key store | Full contract takeover |
+| Scan record integrity | `registry` contract | False security signals; scanners trusted incorrectly |
+| Allowances | token contracts | Unauthorised spend on behalf of another account |
+| Staking rewards | staking contracts | Reward pool drained |
+| Contract WASM | upgrade path | Arbitrary code execution after upgrade |
+
+---
+
+## Trust Boundaries
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Stellar Network (on-chain)                             │
+│                                                         │
+│  ┌──────────────┐   submit_scan()   ┌───────────────┐  │
+│  │  Scanner CLI │ ────────────────► │   registry    │  │
+│  │  (off-chain) │                   │  (admin-gated │  │
+│  └──────────────┘                   │   scanner set)│  │
+│                                     └───────────────┘  │
+│                                                         │
+│  ┌──────────────┐                   ┌───────────────┐  │
+│  │  User / EOA  │ ──── transfer ──► │  vault /      │  │
+│  │  (staker)    │                   │  staking      │  │
+│  └──────────────┘                   └───────────────┘  │
+│                                                         │
+│  ┌──────────────┐                                       │
+│  │  Admin EOA   │ ── upgrade / add_scanner / dispute ─► │
+│  └──────────────┘                                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Key boundaries:**
+
+- The `registry` trusts only admin-approved scanner addresses. An unapproved address cannot submit scan results.
+- Vault and staking contracts trust only the account that owns the funds (`require_auth`).
+- The admin is trusted to act honestly; admin key compromise is an out-of-scope operational risk (see below).
+- Off-chain scanner CLI is trusted to produce correct findings hashes; the registry stores them without validation.
+
+---
+
+## Attack Vectors
+
+### In-scope
+
+| ID  | Vector | Class | Demonstrated by |
+|-----|--------|-------|-----------------|
+| AV-01 | Call state-mutating function without `require_auth` | Missing authorisation | [`missing_auth`](../vulnerable/missing_auth/README.md) |
+| AV-02 | Arithmetic overflow / underflow in reward or balance calc | Integer overflow | [`unchecked_math`](../vulnerable/unchecked_math/README.md), [`underflow_transfer`](../vulnerable/underflow_transfer/README.md) |
+| AV-03 | Persistent storage entry expires (TTL not renewed) | Storage expiry | [`missing_ttl`](../vulnerable/missing_ttl/README.md) |
+| AV-04 | Call `set_admin` or `upgrade` without admin check | Privilege escalation | [`unprotected_admin`](../vulnerable/unprotected_admin/README.md) |
+| AV-05 | Write to any account's storage slot | Unauthorised writes | [`unsafe_storage`](../vulnerable/unsafe_storage/README.md) |
+| AV-06 | Claim rewards multiple times from same stake window | Double-claim | [`double_claim`](../vulnerable/double_claim/README.md) |
+| AV-07 | Divide by zero in fee or rate calculation | Division by zero | [`div_by_zero`](../vulnerable/div_by_zero/README.md) |
+| AV-08 | Transfer negative amount to inflate balance | Negative amount | [`negative_transfer`](../vulnerable/negative_transfer/README.md) |
+| AV-09 | Re-initialise an already-initialised contract | Re-initialisation | [`reinit_attack`](../vulnerable/reinit_attack/README.md) |
+| AV-10 | Emit sensitive data (keys, PII) in contract events | Sensitive data in events | [`leaky_events`](../vulnerable/leaky_events/README.md) |
+| AV-11 | Use string instead of `Address` type for admin | String-typed admin | [`string_admin`](../vulnerable/string_admin/README.md) |
+| AV-12 | Admin transfers ownership without two-step confirmation | Admin rug-pull | [`admin_rugpull`](../vulnerable/admin_rugpull/README.md) |
+| AV-13 | Zero-value deposit accepted, griefing storage | Zero-value deposit | [`zero_deposit`](../vulnerable/zero_deposit/README.md) |
+| AV-14 | Dust deposits fill storage cheaply | Dust griefing | [`dust_griefing`](../vulnerable/dust_griefing/README.md) |
+| AV-15 | Oracle price read from single instant source | Oracle manipulation | [`instant_oracle`](../vulnerable/instant_oracle/README.md) |
+| AV-16 | Swap with no minimum output guard | Slippage | [`no_slippage`](../vulnerable/no_slippage/README.md) |
+| AV-17 | Flash loan repayment not checked before return | Flash-loan re-entry | [`flash_loan_no_check`](../vulnerable/flash_loan_no_check/README.md) |
+| AV-18 | Scanner address not verified against on-chain registry | Scanner spoofing | [`scanner_impersonation`](../vulnerable/scanner_impersonation/README.md) |
+| AV-19 | Allowance not decremented after spend | Allowance bug | [`allowance_not_decremented`](../vulnerable/allowance_not_decremented/README.md) |
+| AV-20 | Storage keys collide across different data types | Key collision | [`key_collision`](../vulnerable/key_collision/README.md) |
+| AV-21 | Burn tokens without owner authorisation | Unprotected burn | [`unprotected_burn`](../vulnerable/unprotected_burn/README.md) |
+| AV-22 | Fee withdrawal open to any caller | Fee drain | [`unprotected_fee_withdraw`](../vulnerable/unprotected_fee_withdraw/README.md) |
+| AV-23 | Delete contract storage without admin check | Storage wipe | [`unprotected_delete`](../vulnerable/unprotected_delete/README.md) |
+| AV-24 | Emergency withdraw open to any caller | Emergency drain | [`unprotected_emergency_withdraw`](../vulnerable/unprotected_emergency_withdraw/README.md) |
+| AV-25 | Self-transfer inflates or corrupts balance | Self-transfer | [`self_transfer`](../vulnerable/self_transfer/README.md) |
+| AV-26 | Re-entrant call before state is committed | Re-entrancy | [`reentrancy`](../vulnerable/reentrancy/README.md) |
+| AV-27 | Admin set to zero address | Zero address admin | [`zero_admin`](../vulnerable/zero_admin/README.md) |
+| AV-28 | Zero-value stake accepted | Zero-value stake | [`zero_stake`](../vulnerable/zero_stake/README.md) |
+| AV-29 | Lock expiry based on `ledger().timestamp()` (manipulable) | Timestamp manipulation | [`timestamp_lock`](../vulnerable/timestamp_lock/README.md) |
+| AV-30 | No events emitted; off-chain indexers blind | Missing events | [`missing_events`](../vulnerable/missing_events/README.md) |
+| AV-31 | Sensitive data stored in plain contract storage | Sensitive storage | [`sensitive_storage`](../vulnerable/sensitive_storage/README.md) |
+| AV-32 | Replay attack — nonce or signature not invalidated | Replay | [`replay_attack`](../vulnerable/replay_attack/README.md) |
+| AV-33 | Unbounded storage growth (no cap on entries) | Unbounded storage | [`unbounded_storage`](../vulnerable/unbounded_storage/README.md) |
+| AV-34 | Uncapped interest / reward rate | Uncapped rate | [`uncapped_rate`](../vulnerable/uncapped_rate/README.md) |
+| AV-35 | Oracle price used after staleness window | Stale oracle | [`stale_oracle`](../vulnerable/stale_oracle/README.md) |
+| AV-36 | Unsafe integer cast (e.g. `u64 as i64`) | Unsafe cast | [`unsafe_cast`](../vulnerable/unsafe_cast/README.md) |
+| AV-37 | Mint function open to any caller | Unprotected mint | [`unprotected_mint`](../vulnerable/unprotected_mint/README.md) |
+| AV-38 | Recursive / deep call stack exhaustion | Call depth | [`call_depth`](../vulnerable/call_depth/README.md) |
+
+### Out-of-scope
+
+| Vector | Reason |
+|--------|--------|
+| Admin private key theft | Operational / key-management risk; outside contract logic |
+| Stellar network-level attacks (consensus, eclipse) | Protocol-level; not addressable in contract code |
+| Front-running via MEV | Stellar's fee-bump mechanism partially mitigates; not modelled here |
+| Off-chain scanner CLI bugs | Separate codebase (`soroban-guard-core`) |
+
+---
+
+## Mitigations
+
+| ID  | Mitigation | Secure reference |
+|-----|-----------|-----------------|
+| AV-01 | `require_auth()` on every state-mutating call | `secure_vault`, `protected_admin` |
+| AV-02 | `checked_add` / `checked_sub` / `checked_mul`; reject negative amounts | `secure_vault` |
+| AV-03 | Call `extend_ttl()` on every persistent write | inline `secure.rs` in `missing_ttl` |
+| AV-04 | Admin auth check before `set_admin` / `upgrade` | `protected_admin` |
+| AV-05 | Account auth before writing to per-account storage | `protected_admin` |
+| AV-06 | Claim flag written to storage before reward transfer | inline `secure.rs` in `double_claim` |
+| AV-07 | Guard divisor `> 0` before division | inline fix |
+| AV-08 | Reject `amount <= 0` at function entry | inline `secure.rs` in `negative_transfer` |
+| AV-09 | Initialised flag in persistent storage; panic if already set | inline fix |
+| AV-10 | Emit only non-sensitive fields in events | inline `secure.rs` in `leaky_events` |
+| AV-11 | Use `Address` type for all admin / account fields | inline `secure.rs` in `string_admin` |
+| AV-12 | Two-step admin transfer (propose + accept) | inline `secure.rs` in `admin_rugpull` |
+| AV-13 | Guard `amount > 0` at deposit entry | inline `secure.rs` in `zero_deposit` |
+| AV-14 | Minimum deposit threshold | `secure/dust_griefing` |
+| AV-15 | TWAP or multi-source oracle | inline `secure.rs` in `instant_oracle` |
+| AV-16 | `min_out` slippage guard | inline `secure.rs` in `no_slippage` |
+| AV-17 | Repayment check before returning from flash loan | inline `secure.rs` in `flash_loan_no_check` |
+| AV-18 | On-chain scanner registry check in `registry` | `registry`, inline `secure.rs` in `scanner_impersonation` |
+| AV-19 | Decrement allowance after every spend | inline `secure.rs` in `allowance_not_decremented` |
+| AV-20 | Namespaced storage keys (enum variants per data type) | inline `secure.rs` in `key_collision` |
+| AV-21 | `require_auth()` on burn | `secure_burn` |
+| AV-22 | Admin auth on fee withdrawal | `protected_fee_withdraw` |
+| AV-23 | Admin auth on storage delete | inline fix |
+| AV-24 | Auth + time-lock on emergency withdraw | inline `secure.rs` in `unprotected_emergency_withdraw` |
+| AV-25 | Reject `from == to` at transfer entry | inline fix |
+| AV-26 | Checks-effects-interactions; write state before external calls | inline `secure.rs` in `reentrancy` |
+| AV-27 | Reject zero address at initialisation | inline fix |
+| AV-28 | Guard `amount > 0` at stake entry | inline `secure.rs` in `zero_stake` |
+| AV-29 | Use `ledger().sequence()` instead of `ledger().timestamp()` | `secure/sequence_lock` |
+| AV-30 | Emit structured events on every state change | inline fix |
+| AV-31 | Never store secrets on-chain; use off-chain key management | inline fix |
+| AV-32 | Invalidate nonce / signature in storage before processing | inline `secure.rs` in `replay_attack` |
+| AV-33 | Cap collection size; use pagination | inline fix |
+| AV-34 | Cap rate at a protocol-defined maximum | inline `secure.rs` in `uncapped_rate` |
+| AV-35 | Reject oracle data older than staleness window | inline `secure.rs` in `stale_oracle` |
+| AV-36 | Use safe cast helpers; validate range before cast | inline fix |
+| AV-37 | Admin auth on mint | inline fix |
+| AV-38 | Limit recursion depth; avoid unbounded call chains | inline fix |
+
+---
+
+## Registry-specific trust model
+
+The `registry` contract has an elevated attack surface because it is the
+authoritative source of scan results consumed by dashboards and the scanner CLI.
+
+- **Scanner spoofing (AV-18):** Any address can call `submit_scan` on a naive
+  registry. The registry mitigates this by maintaining an admin-controlled
+  allowlist and requiring `scanner.require_auth()`.
+- **Batch DoS (registry `get_latest_scans_batch`):** Accepting an unbounded
+  input vector would exhaust host memory. The function caps input at 20
+  addresses and panics otherwise.
+- **Score manipulation:** Only the admin can call `dispute_scan`. Scanners
+  cannot inflate their own score beyond one increment per submission.
+
+---
+
+## See also
+
+- [docs/vulnerabilities.md](./vulnerabilities.md) — detailed per-class write-ups with code examples
+- [vulnerable/*/README.md](../vulnerable/) — per-crate exploit scenarios and fixes
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — how to add new vulnerable contract examples

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -302,6 +302,31 @@ impl ScanRegistry {
         page_results
     }
 
+    /// Retrieve the latest scan result for each contract in the batch.
+    ///
+    /// Returns `None` for any contract that has no scan history.
+    /// Capped at 20 addresses to prevent memory DoS.
+    ///
+    /// # Panics
+    /// Panics if `contracts.len() > 20`.
+    pub fn get_latest_scans_batch(
+        env: Env,
+        contracts: Vec<Address>,
+    ) -> Vec<Option<ScanResult>> {
+        if contracts.len() > 20 {
+            panic!("batch size exceeds maximum of 20");
+        }
+        let mut results: Vec<Option<ScanResult>> = Vec::new(&env);
+        for contract in contracts.iter() {
+            let latest = env
+                .storage()
+                .persistent()
+                .get(&DataKey::LatestScan(contract));
+            results.push_back(latest);
+        }
+        results
+    }
+
     /// Return the admin address of the registry.
     ///
     /// # Returns
@@ -567,5 +592,54 @@ mod tests {
 
         // admin.require_auth() inside dispute_scan is not satisfied → panic.
         ScanRegistryClient::new(&env, &contract_id).dispute_scan(&scanner);
+    }
+
+    // ── get_latest_scans_batch tests ──────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "batch size exceeds maximum of 20")]
+    fn test_batch_too_large_panics() {
+        let (env, contract_id, _admin, _scanner) = setup();
+        let client = ScanRegistryClient::new(&env, &contract_id);
+        let mut contracts: Vec<Address> = Vec::new(&env);
+        for _ in 0..21 {
+            contracts.push_back(Address::generate(&env));
+        }
+        client.get_latest_scans_batch(&contracts);
+    }
+
+    #[test]
+    fn test_batch_returns_latest_and_none_for_unscanned() {
+        let (env, contract_id, _admin, scanner) = setup();
+        let client = ScanRegistryClient::new(&env, &contract_id);
+
+        let scanned1 = Address::generate(&env);
+        let scanned2 = Address::generate(&env);
+        let unscanned = Address::generate(&env);
+
+        let counts: Map<String, u32> = map![&env, (String::from_str(&env, "low"), 1u32)];
+        client.add_scanner(&scanner);
+        client.submit_scan(&scanner, &scanned1, &String::from_str(&env, "h1"), &counts);
+        client.submit_scan(&scanner, &scanned2, &String::from_str(&env, "h2"), &counts);
+
+        let mut batch: Vec<Address> = Vec::new(&env);
+        batch.push_back(scanned1.clone());
+        batch.push_back(scanned2.clone());
+        batch.push_back(unscanned.clone());
+
+        let results = client.get_latest_scans_batch(&batch);
+        assert_eq!(results.len(), 3);
+        assert_eq!(results.get(0).unwrap().unwrap().findings_hash, String::from_str(&env, "h1"));
+        assert_eq!(results.get(1).unwrap().unwrap().findings_hash, String::from_str(&env, "h2"));
+        assert!(results.get(2).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_batch_empty_input_returns_empty() {
+        let (env, contract_id, _admin, _scanner) = setup();
+        let client = ScanRegistryClient::new(&env, &contract_id);
+        let empty: Vec<Address> = Vec::new(&env);
+        let results = client.get_latest_scans_batch(&empty);
+        assert_eq!(results.len(), 0);
     }
 }

--- a/secure/secure_airdrop/Cargo.toml
+++ b/secure/secure_airdrop/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "secure-airdrop"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/secure/secure_airdrop/src/lib.rs
+++ b/secure/secure_airdrop/src/lib.rs
@@ -1,0 +1,244 @@
+//! SECURE: Merkle-proof-based airdrop
+//!
+//! Eligible addresses claim tokens by supplying a Merkle proof against a root
+//! stored at initialisation. One claim per address is enforced via persistent
+//! storage. Only the admin can fund the pool.
+
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, Address, Bytes, BytesN, Env, Vec,
+};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    MerkleRoot,
+    Token,
+    Claimed(Address),
+}
+
+#[contract]
+pub struct SecureAirdrop;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn leaf_hash(env: &Env, claimant: &Address, amount: i128) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.append(&claimant.to_xdr(env));
+    data.extend_from_array(&amount.to_be_bytes());
+    env.crypto().sha256(&data)
+}
+
+/// Hash two 32-byte nodes together, smaller first (canonical ordering).
+fn hash_pair(env: &Env, a: &BytesN<32>, b: &BytesN<32>) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    if a <= b {
+        data.append(&Bytes::from(a.clone()));
+        data.append(&Bytes::from(b.clone()));
+    } else {
+        data.append(&Bytes::from(b.clone()));
+        data.append(&Bytes::from(a.clone()));
+    }
+    env.crypto().sha256(&data)
+}
+
+fn verify_merkle_proof(
+    env: &Env,
+    claimant: &Address,
+    amount: i128,
+    proof: &Vec<BytesN<32>>,
+) {
+    let root: BytesN<32> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::MerkleRoot)
+        .expect("not initialized");
+
+    let mut node = leaf_hash(env, claimant, amount);
+    for sibling in proof.iter() {
+        node = hash_pair(env, &node, &sibling);
+    }
+    assert!(node == root, "invalid merkle proof");
+}
+
+fn is_claimed(env: &Env, claimant: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Claimed(claimant.clone()))
+        .unwrap_or(false)
+}
+
+fn mark_claimed(env: &Env, claimant: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Claimed(claimant.clone()), &true);
+}
+
+// ── contract ─────────────────────────────────────────────────────────────────
+
+#[contractimpl]
+impl SecureAirdrop {
+    pub fn initialize(env: Env, admin: Address, merkle_root: BytesN<32>, token: Address) {
+        assert!(
+            !env.storage().persistent().has(&DataKey::Admin),
+            "already initialized"
+        );
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerkleRoot, &merkle_root);
+        env.storage().persistent().set(&DataKey::Token, &token);
+    }
+
+    /// Admin deposits tokens into the airdrop pool.
+    pub fn fund(env: Env, amount: i128) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let token: Address = env.storage().persistent().get(&DataKey::Token).unwrap();
+        token::Client::new(&env, &token).transfer(&admin, &env.current_contract_address(), &amount);
+
+        env.events()
+            .publish((symbol_short!("fund"),), (admin, amount));
+    }
+
+    /// Claim tokens by providing a valid Merkle proof.
+    /// Marks the address as claimed before transferring (checks-effects-interactions).
+    pub fn claim(env: Env, claimant: Address, amount: i128, proof: Vec<BytesN<32>>) {
+        claimant.require_auth();
+        assert!(!is_claimed(&env, &claimant), "already claimed");
+        verify_merkle_proof(&env, &claimant, amount, &proof);
+
+        // ✅ Mark claimed BEFORE transfer (checks-effects-interactions)
+        mark_claimed(&env, &claimant);
+
+        let token: Address = env.storage().persistent().get(&DataKey::Token).unwrap();
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &claimant,
+            &amount,
+        );
+
+        env.events()
+            .publish((symbol_short!("claim"),), (claimant, amount));
+    }
+
+    pub fn get_claimed(env: Env, address: Address) -> bool {
+        is_claimed(&env, &address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::Address as _,
+        token::{Client as TokenClient, StellarAssetClient},
+        Address, BytesN, Env, Vec,
+    };
+
+    /// Build a two-leaf Merkle tree for `claimant` and return (root, proof).
+    /// Tree:
+    ///   leaf0 = hash(claimant, amount)
+    ///   leaf1 = hash(other, 0)          ← dummy second leaf
+    ///   root  = hash_pair(leaf0, leaf1)
+    fn build_tree(
+        env: &Env,
+        claimant: &Address,
+        amount: i128,
+        other: &Address,
+    ) -> (BytesN<32>, Vec<BytesN<32>>) {
+        let leaf0 = leaf_hash(env, claimant, amount);
+        let leaf1 = leaf_hash(env, other, 0i128);
+        let root = hash_pair(env, &leaf0, &leaf1);
+        let mut proof = Vec::new(env);
+        proof.push_back(leaf1);
+        (root, proof)
+    }
+
+    fn setup() -> (Env, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        // Deploy a native/SAC token for testing
+        let admin = Address::generate(&env);
+        let claimant = Address::generate(&env);
+        let other = Address::generate(&env);
+
+        let token_admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+
+        // Mint tokens to admin so they can fund the airdrop
+        StellarAssetClient::new(&env, &token_id).mint(&admin, &10_000);
+
+        (env, token_id, admin, claimant, other)
+    }
+
+    #[test]
+    fn test_valid_proof_claims_successfully() {
+        let (env, token_id, admin, claimant, other) = setup();
+        let amount = 500i128;
+
+        let (root, proof) = build_tree(&env, &claimant, amount, &other);
+
+        let contract_id = env.register_contract(None, SecureAirdrop);
+        let client = SecureAirdropClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &root, &token_id);
+        client.fund(&amount);
+
+        assert!(!client.get_claimed(&claimant));
+        client.claim(&claimant, &amount, &proof);
+        assert!(client.get_claimed(&claimant));
+
+        // Claimant received the tokens
+        assert_eq!(TokenClient::new(&env, &token_id).balance(&claimant), amount);
+    }
+
+    #[test]
+    #[should_panic(expected = "already claimed")]
+    fn test_double_claim_panics() {
+        let (env, token_id, admin, claimant, other) = setup();
+        let amount = 500i128;
+
+        let (root, proof) = build_tree(&env, &claimant, amount, &other);
+
+        let contract_id = env.register_contract(None, SecureAirdrop);
+        let client = SecureAirdropClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &root, &token_id);
+        client.fund(&(amount * 2));
+
+        client.claim(&claimant, &amount, &proof);
+        // Second claim must panic
+        client.claim(&claimant, &amount, &proof);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid merkle proof")]
+    fn test_invalid_proof_rejected_before_state_change() {
+        let (env, token_id, admin, claimant, other) = setup();
+        let amount = 500i128;
+
+        let (root, _valid_proof) = build_tree(&env, &claimant, amount, &other);
+
+        let contract_id = env.register_contract(None, SecureAirdrop);
+        let client = SecureAirdropClient::new(&env, &contract_id);
+
+        client.initialize(&admin, &root, &token_id);
+        client.fund(&amount);
+
+        // Construct a bogus proof
+        let mut bad_proof: Vec<BytesN<32>> = Vec::new(&env);
+        bad_proof.push_back(BytesN::from_array(&env, &[0u8; 32]));
+
+        client.claim(&claimant, &amount, &bad_proof);
+
+        // State must not have changed
+        assert!(!client.get_claimed(&claimant));
+    }
+}

--- a/vulnerable/README_TEMPLATE.md
+++ b/vulnerable/README_TEMPLATE.md
@@ -1,0 +1,37 @@
+# `vulnerable/<crate_name>`
+
+## Vulnerability: <Name>
+
+**Severity:** <Critical | High | Medium | Low>
+
+## Description
+
+<2–3 sentences describing the flaw and why it is dangerous.>
+
+## Exploit Scenario
+
+1. Attacker calls `<function>` with `<parameters>`.
+2. Contract executes without checking `<invariant>`.
+3. Attacker gains `<outcome>`.
+
+## Vulnerable Code
+
+```rust
+// see src/lib.rs
+<paste the vulnerable snippet here>
+```
+
+## Secure Fix
+
+```rust
+// corrected version
+<paste the fixed snippet here>
+```
+
+See [`secure/<mirror_crate>`](../../secure/<mirror_crate>) for the full corrected implementation,
+or the inline `secure.rs` module inside this crate if no separate secure crate exists.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/admin_rugpull/README.md
+++ b/vulnerable/admin_rugpull/README.md
@@ -1,0 +1,47 @@
+# `vulnerable/admin_rugpull`
+
+## Vulnerability: Admin Rug-Pull (Single-Step Admin Transfer)
+
+**Severity:** High
+
+## Description
+
+`set_admin()` immediately replaces the admin in a single transaction. There is no confirmation step from the new admin. A compromised or malicious admin can transfer control to an attacker-controlled address instantly, with no recovery window.
+
+## Exploit Scenario
+
+1. Admin key is compromised.
+2. Attacker calls `set_admin(attacker_address)` in one transaction.
+3. Attacker immediately controls all privileged functions; original admin has no recourse.
+
+## Vulnerable Code
+
+```rust
+pub fn set_admin(env: Env, new_admin: Address) {
+    require_admin(&env);
+    // ❌ Immediate transfer — no acceptance step
+    env.storage().persistent().set(&DataKey::Admin, &new_admin);
+}
+```
+
+## Secure Fix
+
+```rust
+// Two-step: propose then accept
+pub fn propose_admin(env: Env, new_admin: Address) {
+    require_admin(&env);
+    env.storage().persistent().set(&DataKey::PendingAdmin, &new_admin); // ✅
+}
+pub fn accept_admin(env: Env) {
+    let pending: Address = env.storage().persistent().get(&DataKey::PendingAdmin).unwrap();
+    pending.require_auth(); // ✅ new admin must sign
+    env.storage().persistent().set(&DataKey::Admin, &pending);
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/allowance_not_decremented/README.md
+++ b/vulnerable/allowance_not_decremented/README.md
@@ -1,0 +1,42 @@
+# `vulnerable/allowance_not_decremented`
+
+## Vulnerability: Allowance Not Decremented After Spend
+
+**Severity:** High
+
+## Description
+
+After a `transfer_from` spends an allowance, the contract does not reduce the stored allowance. The spender can call `transfer_from` repeatedly, draining the owner's balance far beyond the approved amount.
+
+## Exploit Scenario
+
+1. Alice approves Bob for 100 tokens.
+2. Bob calls `transfer_from(alice, bob, 100)` — succeeds.
+3. Bob calls `transfer_from(alice, bob, 100)` again — still succeeds because the allowance was never decremented.
+4. Bob drains Alice's entire balance.
+
+## Vulnerable Code
+
+```rust
+pub fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
+    spender.require_auth();
+    let allowance = get_allowance(&env, &from, &spender);
+    assert!(allowance >= amount, "insufficient allowance");
+    // ❌ Missing: set_allowance(&env, &from, &spender, allowance - amount);
+    do_transfer(&env, &from, &to, amount);
+}
+```
+
+## Secure Fix
+
+```rust
+set_allowance(&env, &from, &spender, allowance - amount); // ✅
+do_transfer(&env, &from, &to, amount);
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/call_depth/README.md
+++ b/vulnerable/call_depth/README.md
@@ -1,0 +1,41 @@
+# `vulnerable/call_depth`
+
+## Vulnerability: Call Depth Exhaustion
+
+**Severity:** Medium
+
+## Description
+
+The contract makes recursive or deeply nested cross-contract calls without limiting the call depth. Soroban enforces a maximum call stack depth; an attacker can craft a call chain that hits this limit, causing an uncontrolled trap and potentially leaving the contract in an inconsistent state.
+
+## Exploit Scenario
+
+1. Attacker deploys a contract that calls back into the vulnerable contract.
+2. The vulnerable contract calls the attacker's contract, which calls back, and so on.
+3. The call stack hits the Soroban limit; the transaction fails with a trap.
+4. If state was partially written before the trap, the contract may be in an inconsistent state.
+
+## Vulnerable Code
+
+```rust
+pub fn process(env: Env, next: Address) {
+    // ❌ No depth limit — can be chained arbitrarily
+    ContractClient::new(&env, &next).process(&env.current_contract_address());
+}
+```
+
+## Secure Fix
+
+Track call depth in storage and reject calls that exceed a safe limit.
+
+```rust
+let depth: u32 = env.storage().temporary().get(&DataKey::Depth).unwrap_or(0);
+assert!(depth < MAX_DEPTH, "call depth exceeded"); // ✅
+```
+
+No separate secure crate — the fix is an inline depth guard.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/div_by_zero/README.md
+++ b/vulnerable/div_by_zero/README.md
@@ -1,0 +1,35 @@
+# `vulnerable/div_by_zero`
+
+## Vulnerability: Division by Zero
+
+**Severity:** High
+
+## Description
+
+A fee or rate calculation divides by a value that can be zero (e.g. total supply, pool size, or a user-supplied denominator). When the divisor is zero, the contract panics with an uncontrolled trap, potentially bricking the contract or enabling a DoS.
+
+## Exploit Scenario
+
+1. Attacker drains the pool to zero (or the pool starts empty).
+2. Any user calls a function that divides by the pool size.
+3. Contract panics; the function is unusable until the pool is refilled.
+
+## Vulnerable Code
+
+```rust
+let fee = total_fees / total_shares; // ❌ panics if total_shares == 0
+```
+
+## Secure Fix
+
+```rust
+assert!(total_shares > 0, "no shares outstanding"); // ✅
+let fee = total_fees / total_shares;
+```
+
+No separate secure crate — the fix is an inline guard.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/double_claim/README.md
+++ b/vulnerable/double_claim/README.md
@@ -1,0 +1,42 @@
+# `vulnerable/double_claim`
+
+## Vulnerability: Double-Claim (Stale Timestamp)
+
+**Severity:** Critical
+
+## Description
+
+`claim_rewards` computes rewards based on elapsed ledgers since `staked_at`, but never resets `staked_at` after paying out. The same elapsed window can be claimed repeatedly, draining the reward pool.
+
+## Exploit Scenario
+
+1. Staker stakes tokens; `staked_at` is recorded.
+2. Staker waits N ledgers, then calls `claim_rewards` — receives reward for N ledgers.
+3. Staker calls `claim_rewards` again immediately — receives the same reward again because `staked_at` was not updated.
+4. Staker repeats until the reward pool is empty.
+
+## Vulnerable Code
+
+```rust
+pub fn claim_rewards(env: Env, staker: Address) -> u64 {
+    let elapsed = env.ledger().sequence() - get_staked_at(&env, &staker);
+    let reward = stake * rate * elapsed as u64;
+    // ❌ Missing: set_staked_at(&env, &staker, env.ledger().sequence());
+    reward
+}
+```
+
+## Secure Fix
+
+```rust
+let reward = stake * rate * elapsed as u64;
+set_staked_at(&env, &staker, env.ledger().sequence()); // ✅ reset window
+reward
+```
+
+No separate secure crate — see the inline test in this crate demonstrating the fix.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/dust_griefing/README.md
+++ b/vulnerable/dust_griefing/README.md
@@ -1,0 +1,44 @@
+# `vulnerable/dust_griefing`
+
+## Vulnerability: Dust Griefing
+
+**Severity:** Medium
+
+## Description
+
+The contract accepts deposits of any positive amount, including dust (e.g. 1 stroop). An attacker can flood the contract with tiny deposits from many addresses, bloating persistent storage and raising costs for all users.
+
+## Exploit Scenario
+
+1. Attacker creates thousands of accounts and calls `deposit(account_n, 1)` from each.
+2. Each call creates a new persistent storage entry.
+3. Storage rent costs rise; legitimate users pay more to interact with the contract.
+
+## Vulnerable Code
+
+```rust
+pub fn deposit(env: Env, account: Address, amount: i128) {
+    account.require_auth();
+    // ❌ No minimum deposit threshold
+    set_balance(&env, &account, get_balance(&env, &account) + amount);
+}
+```
+
+## Secure Fix
+
+```rust
+const MIN_DEPOSIT: i128 = 10_000_000; // 1 XLM in stroops
+
+pub fn deposit(env: Env, account: Address, amount: i128) {
+    account.require_auth();
+    assert!(amount >= MIN_DEPOSIT, "deposit below minimum"); // ✅
+    // ...
+}
+```
+
+See [`secure/dust_griefing`](../../secure/dust_griefing) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/flash_loan_no_check/README.md
+++ b/vulnerable/flash_loan_no_check/README.md
@@ -1,0 +1,44 @@
+# `vulnerable/flash_loan_no_check`
+
+## Vulnerability: Flash Loan Without Repayment Check
+
+**Severity:** Critical
+
+## Description
+
+The flash loan function transfers tokens to the borrower but does not verify repayment before returning. An attacker can borrow the entire pool and never repay, draining the contract.
+
+## Exploit Scenario
+
+1. Attacker calls `flash_loan(attacker, pool_balance)`.
+2. Contract transfers tokens to attacker.
+3. Attacker does not repay; contract returns without checking the balance was restored.
+4. Attacker keeps the tokens.
+
+## Vulnerable Code
+
+```rust
+pub fn flash_loan(env: Env, borrower: Address, amount: i128) {
+    transfer_out(&env, &borrower, amount);
+    // ❌ Missing repayment check
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn flash_loan(env: Env, borrower: Address, amount: i128) {
+    let balance_before = get_pool_balance(&env);
+    transfer_out(&env, &borrower, amount);
+    // borrower executes their logic here (via callback or same tx)
+    let balance_after = get_pool_balance(&env);
+    assert!(balance_after >= balance_before, "flash loan not repaid"); // ✅
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/instant_oracle/README.md
+++ b/vulnerable/instant_oracle/README.md
@@ -1,0 +1,36 @@
+# `vulnerable/instant_oracle`
+
+## Vulnerability: Oracle Manipulation (Instant Price)
+
+**Severity:** High
+
+## Description
+
+The contract reads a price from a single oracle source at the exact moment of the transaction. An attacker who can influence the oracle (e.g. via a flash loan) can set an arbitrary price for one block, then exploit the contract at that manipulated price.
+
+## Exploit Scenario
+
+1. Attacker takes a flash loan to move the oracle price to an extreme value.
+2. Attacker calls the contract function that reads the oracle price.
+3. Contract executes at the manipulated price; attacker profits and repays the flash loan.
+
+## Vulnerable Code
+
+```rust
+let price = oracle::get_price(&env); // ❌ single instant read
+let value = amount * price;
+```
+
+## Secure Fix
+
+```rust
+let price = oracle::get_twap(&env, TWAP_WINDOW); // ✅ time-weighted average
+let value = amount * price;
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/key_collision/README.md
+++ b/vulnerable/key_collision/README.md
@@ -1,0 +1,38 @@
+# `vulnerable/key_collision`
+
+## Vulnerability: Storage Key Collision
+
+**Severity:** High
+
+## Description
+
+Two different data types (e.g. user balances and allowances) are stored under keys derived from the same address without a namespace prefix. A write to one data type can silently overwrite the other, corrupting contract state.
+
+## Exploit Scenario
+
+1. Contract stores `Balance(alice)` and `Allowance(alice)` using the same raw key.
+2. A balance update overwrites the allowance entry (or vice versa).
+3. Alice's allowance is corrupted; a spender can drain more than permitted.
+
+## Vulnerable Code
+
+```rust
+// ❌ Both use the same key derivation
+env.storage().persistent().set(&account, &balance);
+env.storage().persistent().set(&account, &allowance);
+```
+
+## Secure Fix
+
+```rust
+// ✅ Namespaced enum variants
+env.storage().persistent().set(&DataKey::Balance(account.clone()), &balance);
+env.storage().persistent().set(&DataKey::Allowance(account.clone()), &allowance);
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/leaky_events/README.md
+++ b/vulnerable/leaky_events/README.md
@@ -1,0 +1,40 @@
+# `vulnerable/leaky_events`
+
+## Vulnerability: Sensitive Data in Events
+
+**Severity:** Medium
+
+## Description
+
+The contract emits private data (e.g. private keys, passwords, or PII) in contract events. Soroban events are publicly visible on-chain and to any indexer, so sensitive data is permanently exposed.
+
+## Exploit Scenario
+
+1. Contract emits an event containing a user's private key or secret.
+2. Any on-chain observer or indexer reads the event data.
+3. Attacker uses the leaked secret to compromise the user's account.
+
+## Vulnerable Code
+
+```rust
+env.events().publish(
+    (symbol_short!("register"),),
+    (account.clone(), private_key, password), // ❌ sensitive fields
+);
+```
+
+## Secure Fix
+
+```rust
+env.events().publish(
+    (symbol_short!("register"),),
+    (account.clone(),), // ✅ emit only non-sensitive identifier
+);
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/missing_auth/README.md
+++ b/vulnerable/missing_auth/README.md
@@ -1,0 +1,42 @@
+# `vulnerable/missing_auth`
+
+## Vulnerability: Missing Authorisation
+
+**Severity:** Critical
+
+## Description
+
+The `transfer()` function mutates token balances without calling `require_auth()` on the sender. Any account can move tokens out of any other account's balance without their consent.
+
+## Exploit Scenario
+
+1. Attacker calls `transfer(victim, attacker, 1_000_000)`.
+2. Contract updates balances without verifying the victim signed the transaction.
+3. Attacker drains the victim's entire balance.
+
+## Vulnerable Code
+
+```rust
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    // ❌ Missing: from.require_auth();
+    let from_balance = get_balance(&env, &from);
+    set_balance(&env, &from, from_balance - amount);
+    // ...
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth(); // ✅
+    // ...
+}
+```
+
+See [`secure/secure_vault`](../../secure/secure_vault) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/missing_events/README.md
+++ b/vulnerable/missing_events/README.md
@@ -1,0 +1,39 @@
+# `vulnerable/missing_events`
+
+## Vulnerability: No Events Emitted
+
+**Severity:** Low
+
+## Description
+
+The contract mutates state (transfers, admin changes, etc.) without emitting any events. Off-chain indexers, dashboards, and audit tools are blind to these state changes, making it impossible to detect suspicious activity or reconstruct history.
+
+## Exploit Scenario
+
+1. Attacker exploits another vulnerability (e.g. missing auth) to drain funds.
+2. No events are emitted; the exploit is invisible to monitoring systems.
+3. The attack goes undetected until a user notices their balance is zero.
+
+## Vulnerable Code
+
+```rust
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth();
+    do_transfer(&env, &from, &to, amount);
+    // ❌ Missing: env.events().publish(...)
+}
+```
+
+## Secure Fix
+
+```rust
+do_transfer(&env, &from, &to, amount);
+env.events().publish((symbol_short!("transfer"),), (from, to, amount)); // ✅
+```
+
+No separate secure crate — the fix is adding event emissions to each state-mutating function.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/missing_ttl/README.md
+++ b/vulnerable/missing_ttl/README.md
@@ -1,0 +1,37 @@
+# `vulnerable/missing_ttl`
+
+## Vulnerability: Storage Expiry (Missing TTL Renewal)
+
+**Severity:** High
+
+## Description
+
+Persistent storage entries on Soroban have a time-to-live (TTL). This contract writes balances to persistent storage but never calls `extend_ttl()`. After enough ledgers pass, the balance entry expires and is deleted, causing users to lose their funds silently.
+
+## Exploit Scenario
+
+1. User deposits tokens; balance is written to persistent storage.
+2. No activity occurs for the TTL window.
+3. The storage entry expires; the user's balance is now `0` (default).
+4. A subsequent transfer or withdrawal fails or succeeds with a zero balance.
+
+## Vulnerable Code
+
+```rust
+env.storage().persistent().set(&key, &new_balance);
+// ❌ Missing: env.storage().persistent().extend_ttl(&key, threshold, extend_to);
+```
+
+## Secure Fix
+
+```rust
+env.storage().persistent().set(&key, &new_balance);
+env.storage().persistent().extend_ttl(&key, LOW_WATERMARK, HIGH_WATERMARK); // ✅
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/negative_transfer/README.md
+++ b/vulnerable/negative_transfer/README.md
@@ -1,0 +1,39 @@
+# `vulnerable/negative_transfer`
+
+## Vulnerability: Negative Amount Transfer
+
+**Severity:** High
+
+## Description
+
+The transfer function accepts negative `amount` values. Transferring a negative amount effectively moves tokens in the reverse direction, allowing an attacker to inflate their own balance by "sending" a negative amount to themselves or others.
+
+## Exploit Scenario
+
+1. Attacker calls `transfer(attacker, victim, -1_000_000)`.
+2. Contract subtracts `-1_000_000` from the attacker's balance (adding 1M) and adds `-1_000_000` to the victim's balance (subtracting 1M).
+3. Attacker gains tokens; victim loses tokens.
+
+## Vulnerable Code
+
+```rust
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth();
+    // ❌ Missing: assert!(amount > 0, "amount must be positive");
+    set_balance(&env, &from, get_balance(&env, &from) - amount);
+    set_balance(&env, &to, get_balance(&env, &to) + amount);
+}
+```
+
+## Secure Fix
+
+```rust
+assert!(amount > 0, "amount must be positive"); // ✅
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/no_slippage/README.md
+++ b/vulnerable/no_slippage/README.md
@@ -1,0 +1,45 @@
+# `vulnerable/no_slippage`
+
+## Vulnerability: Missing Slippage Guard
+
+**Severity:** High
+
+## Description
+
+The swap function executes without a minimum output (`min_out`) parameter. A front-runner or sandwich attacker can manipulate the pool price between the user's transaction submission and execution, causing the user to receive far less than expected.
+
+## Exploit Scenario
+
+1. User submits a swap for token A → token B.
+2. Attacker front-runs with a large buy of token B, moving the price.
+3. User's swap executes at the worse price; attacker back-runs to profit.
+4. User receives significantly less than the quoted amount.
+
+## Vulnerable Code
+
+```rust
+pub fn swap(env: Env, amount_in: i128) -> i128 {
+    // ❌ No min_out check
+    let amount_out = calculate_out(&env, amount_in);
+    execute_swap(&env, amount_in, amount_out);
+    amount_out
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn swap(env: Env, amount_in: i128, min_out: i128) -> i128 {
+    let amount_out = calculate_out(&env, amount_in);
+    assert!(amount_out >= min_out, "slippage exceeded"); // ✅
+    execute_swap(&env, amount_in, amount_out);
+    amount_out
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/reentrancy/README.md
+++ b/vulnerable/reentrancy/README.md
@@ -1,0 +1,45 @@
+# `vulnerable/reentrancy`
+
+## Vulnerability: Re-Entrancy
+
+**Severity:** Critical
+
+## Description
+
+The contract makes an external call (e.g. token transfer) before updating its own state. If the external contract calls back into the vulnerable contract before the state update, it can exploit the stale state — for example, withdrawing the same funds twice.
+
+## Exploit Scenario
+
+1. Attacker calls `withdraw(100)`.
+2. Contract sends 100 tokens to the attacker's contract via an external call.
+3. Attacker's contract immediately calls `withdraw(100)` again.
+4. The vulnerable contract's balance has not been updated yet; the second withdrawal succeeds.
+5. Attacker receives 200 tokens for a 100-token balance.
+
+## Vulnerable Code
+
+```rust
+pub fn withdraw(env: Env, account: Address, amount: i128) {
+    account.require_auth();
+    let balance = get_balance(&env, &account);
+    assert!(balance >= amount, "insufficient balance");
+    token_client.transfer(&env.current_contract_address(), &account, &amount); // ❌ external call first
+    set_balance(&env, &account, balance - amount); // state updated after
+}
+```
+
+## Secure Fix
+
+Apply checks-effects-interactions: update state before making external calls.
+
+```rust
+set_balance(&env, &account, balance - amount); // ✅ state first
+token_client.transfer(&env.current_contract_address(), &account, &amount);
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/reinit_attack/README.md
+++ b/vulnerable/reinit_attack/README.md
@@ -1,0 +1,44 @@
+# `vulnerable/reinit_attack`
+
+## Vulnerability: Re-Initialisation Attack
+
+**Severity:** Critical
+
+## Description
+
+The `initialize` function does not check whether the contract has already been initialised. An attacker can call it again to replace the admin, reset parameters, or wipe state, taking full control of the contract.
+
+## Exploit Scenario
+
+1. Contract is deployed and initialised by the legitimate admin.
+2. Attacker calls `initialize(attacker_address)`.
+3. Contract overwrites the admin with the attacker's address.
+4. Attacker controls all privileged functions.
+
+## Vulnerable Code
+
+```rust
+pub fn initialize(env: Env, admin: Address) {
+    // ❌ Missing: assert!(!env.storage().persistent().has(&DataKey::Admin), "already initialized");
+    env.storage().persistent().set(&DataKey::Admin, &admin);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn initialize(env: Env, admin: Address) {
+    assert!(
+        !env.storage().persistent().has(&DataKey::Admin),
+        "already initialized" // ✅
+    );
+    env.storage().persistent().set(&DataKey::Admin, &admin);
+}
+```
+
+No separate secure crate — the fix is an inline guard.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/replay_attack/README.md
+++ b/vulnerable/replay_attack/README.md
@@ -1,0 +1,41 @@
+# `vulnerable/replay_attack`
+
+## Vulnerability: Replay Attack (Missing Nonce)
+
+**Severity:** High
+
+## Description
+
+The contract processes signed messages or actions without invalidating them after use. An attacker can capture a valid signed message and replay it multiple times, executing the same action repeatedly.
+
+## Exploit Scenario
+
+1. Alice signs a withdrawal request for 100 tokens.
+2. The contract processes the request and pays Alice.
+3. Attacker replays the same signed message; the contract pays out again.
+4. Attacker repeats until the pool is drained.
+
+## Vulnerable Code
+
+```rust
+pub fn withdraw(env: Env, signature: BytesN<32>, amount: i128) {
+    verify_signature(&env, &signature, amount);
+    // ❌ Missing: mark signature as used
+    do_withdraw(&env, amount);
+}
+```
+
+## Secure Fix
+
+```rust
+assert!(!is_used(&env, &signature), "signature already used"); // ✅
+mark_used(&env, &signature);
+do_withdraw(&env, amount);
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/scanner_impersonation/README.md
+++ b/vulnerable/scanner_impersonation/README.md
@@ -1,0 +1,44 @@
+# `vulnerable/scanner_impersonation`
+
+## Vulnerability: Scanner Spoofing
+
+**Severity:** High
+
+## Description
+
+The contract accepts scan result submissions from any address without verifying the caller is a registered scanner. An attacker can submit false scan results, marking vulnerable contracts as safe or safe contracts as vulnerable.
+
+## Exploit Scenario
+
+1. Attacker calls `submit_scan(attacker, target, "clean_hash", counts)`.
+2. Contract stores the result without checking the attacker is an approved scanner.
+3. Dashboards display the false result; users trust a vulnerable contract.
+
+## Vulnerable Code
+
+```rust
+pub fn submit_scan(env: Env, scanner: Address, contract_address: Address, ...) {
+    scanner.require_auth();
+    // ❌ Missing: verify scanner is in the approved list
+    store_result(&env, &contract_address, result);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn submit_scan(env: Env, scanner: Address, contract_address: Address, ...) {
+    scanner.require_auth();
+    let approved: bool = env.storage().persistent()
+        .get(&DataKey::Scanner(scanner.clone())).unwrap_or(false);
+    assert!(approved, "not a verified scanner"); // ✅
+    store_result(&env, &contract_address, result);
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/self_transfer/README.md
+++ b/vulnerable/self_transfer/README.md
@@ -1,0 +1,41 @@
+# `vulnerable/self_transfer`
+
+## Vulnerability: Self-Transfer
+
+**Severity:** Medium
+
+## Description
+
+The transfer function allows `from == to`. A self-transfer can corrupt balance accounting if the implementation reads the balance before both writes, effectively doubling the balance or causing other unexpected state.
+
+## Exploit Scenario
+
+1. Attacker calls `transfer(attacker, attacker, balance)`.
+2. Contract reads `from_balance`, subtracts amount, then reads `to_balance` (same slot, now reduced), and adds amount — net result may be incorrect depending on read order.
+3. Attacker's balance is corrupted in their favour.
+
+## Vulnerable Code
+
+```rust
+pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+    from.require_auth();
+    // ❌ Missing: assert!(from != to, "self-transfer not allowed");
+    let from_bal = get_balance(&env, &from);
+    let to_bal = get_balance(&env, &to);
+    set_balance(&env, &from, from_bal - amount);
+    set_balance(&env, &to, to_bal + amount);
+}
+```
+
+## Secure Fix
+
+```rust
+assert!(from != to, "self-transfer not allowed"); // ✅
+```
+
+No separate secure crate — the fix is an inline guard.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/sensitive_storage/README.md
+++ b/vulnerable/sensitive_storage/README.md
@@ -1,0 +1,38 @@
+# `vulnerable/sensitive_storage`
+
+## Vulnerability: Sensitive Data in Contract Storage
+
+**Severity:** High
+
+## Description
+
+The contract stores sensitive data (private keys, passwords, API secrets) in on-chain persistent storage. All Soroban contract storage is publicly readable by anyone with access to the ledger state, so secrets stored on-chain are immediately compromised.
+
+## Exploit Scenario
+
+1. Contract stores a private key or API secret in persistent storage.
+2. Any observer queries the ledger state (via RPC or explorer).
+3. The secret is read in plaintext; the attacker uses it to compromise the associated system.
+
+## Vulnerable Code
+
+```rust
+env.storage().persistent().set(&DataKey::ApiKey, &secret_key); // ❌ public!
+```
+
+## Secure Fix
+
+Never store secrets on-chain. Use off-chain key management (HSM, KMS, or environment variables). Store only public identifiers or hashed commitments on-chain.
+
+```rust
+// ✅ Store only a hash commitment, never the secret itself
+let commitment = env.crypto().sha256(&secret_bytes);
+env.storage().persistent().set(&DataKey::Commitment, &commitment);
+```
+
+No separate secure crate — this is an architectural fix.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/stale_oracle/README.md
+++ b/vulnerable/stale_oracle/README.md
@@ -1,0 +1,41 @@
+# `vulnerable/stale_oracle`
+
+## Vulnerability: Stale Oracle Price
+
+**Severity:** High
+
+## Description
+
+The contract uses an oracle price without checking when it was last updated. If the oracle stops publishing (due to downtime or manipulation), the contract continues operating on an arbitrarily old price, enabling profitable arbitrage against the stale rate.
+
+## Exploit Scenario
+
+1. Oracle stops updating; the last price is 30 minutes old.
+2. The real market price has moved 20%.
+3. Attacker trades against the contract at the stale price, extracting the price difference.
+
+## Vulnerable Code
+
+```rust
+let price = oracle::get_price(&env);
+// ❌ Missing: assert!(price.updated_at + MAX_STALENESS >= env.ledger().timestamp());
+let value = amount * price.value;
+```
+
+## Secure Fix
+
+```rust
+let price = oracle::get_price(&env);
+assert!(
+    price.updated_at + MAX_STALENESS_SECONDS >= env.ledger().timestamp(),
+    "oracle price is stale" // ✅
+);
+let value = amount * price.value;
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/string_admin/README.md
+++ b/vulnerable/string_admin/README.md
@@ -1,0 +1,41 @@
+# `vulnerable/string_admin`
+
+## Vulnerability: String-Typed Admin
+
+**Severity:** High
+
+## Description
+
+The admin is stored as a `String` instead of an `Address`. String comparison is case-sensitive and error-prone; it bypasses Soroban's built-in auth system (`require_auth`), making it trivial to spoof the admin by passing a matching string without actually controlling the corresponding key.
+
+## Exploit Scenario
+
+1. Admin is stored as `"GADMIN123..."` (a string).
+2. Attacker calls `admin_action("GADMIN123...")` — the string matches.
+3. No cryptographic proof is required; the attacker gains admin access.
+
+## Vulnerable Code
+
+```rust
+pub fn set_admin(env: Env, caller: String, new_admin: String) {
+    let admin: String = env.storage().persistent().get(&DataKey::Admin).unwrap();
+    assert!(caller == admin, "not admin"); // ❌ string comparison, no crypto
+    env.storage().persistent().set(&DataKey::Admin, &new_admin);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn set_admin(env: Env, new_admin: Address) {
+    require_admin(&env); // ✅ uses Address + require_auth()
+    env.storage().persistent().set(&DataKey::Admin, &new_admin);
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/timestamp_lock/README.md
+++ b/vulnerable/timestamp_lock/README.md
@@ -1,0 +1,36 @@
+# `vulnerable/timestamp_lock`
+
+## Vulnerability: Timestamp Manipulation
+
+**Severity:** Medium
+
+## Description
+
+The contract uses `env.ledger().timestamp()` to enforce a time-lock. Stellar validators have limited but non-zero ability to influence the ledger close time. An attacker who controls a validator (or colludes with one) can manipulate the timestamp to bypass the lock early.
+
+## Exploit Scenario
+
+1. Contract enforces a 24-hour lock using `ledger().timestamp()`.
+2. Attacker colludes with a validator to advance the timestamp by 24 hours in one ledger.
+3. Lock is bypassed; attacker withdraws funds before the intended unlock time.
+
+## Vulnerable Code
+
+```rust
+let now = env.ledger().timestamp();
+assert!(now >= unlock_time, "still locked"); // ❌ timestamp is manipulable
+```
+
+## Secure Fix
+
+```rust
+let seq = env.ledger().sequence();
+assert!(seq >= unlock_sequence, "still locked"); // ✅ sequence is monotonic and harder to manipulate
+```
+
+See [`secure/sequence_lock`](../../secure/sequence_lock) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unbounded_storage/README.md
+++ b/vulnerable/unbounded_storage/README.md
@@ -1,0 +1,40 @@
+# `vulnerable/unbounded_storage`
+
+## Vulnerability: Unbounded Storage Growth
+
+**Severity:** Medium
+
+## Description
+
+The contract appends entries to a collection (e.g. a history list or participant registry) without any cap. An attacker can grow the collection indefinitely, causing storage rent to skyrocket and making reads/writes prohibitively expensive or impossible.
+
+## Exploit Scenario
+
+1. Attacker calls `register()` or `submit()` thousands of times from different addresses.
+2. Each call appends an entry to an unbounded `Vec` in persistent storage.
+3. The storage entry grows until reads hit host memory limits or rent becomes unaffordable.
+
+## Vulnerable Code
+
+```rust
+pub fn register(env: Env, account: Address) {
+    let mut list: Vec<Address> = get_list(&env);
+    list.push_back(account); // ❌ no cap
+    set_list(&env, &list);
+}
+```
+
+## Secure Fix
+
+```rust
+const MAX_ENTRIES: u32 = 1000;
+assert!(list.len() < MAX_ENTRIES, "registry full"); // ✅
+list.push_back(account);
+```
+
+No separate secure crate — the fix is an inline cap.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/uncapped_rate/README.md
+++ b/vulnerable/uncapped_rate/README.md
@@ -1,0 +1,44 @@
+# `vulnerable/uncapped_rate`
+
+## Vulnerability: Uncapped Interest / Reward Rate
+
+**Severity:** High
+
+## Description
+
+The admin can set the reward or interest rate to an arbitrarily large value. A malicious or compromised admin can set the rate to `u64::MAX`, causing the next reward claim to overflow or drain the entire pool in a single transaction.
+
+## Exploit Scenario
+
+1. Admin (or attacker who has taken over admin) calls `set_rate(u64::MAX)`.
+2. Any staker calls `claim_rewards`; the reward calculation overflows or returns an enormous value.
+3. The reward pool is drained in one transaction.
+
+## Vulnerable Code
+
+```rust
+pub fn set_rate(env: Env, rate: u64) {
+    require_admin(&env);
+    // ❌ No upper bound on rate
+    env.storage().persistent().set(&DataKey::Rate, &rate);
+}
+```
+
+## Secure Fix
+
+```rust
+const MAX_RATE: u64 = 10_000; // 100% APR in basis points
+
+pub fn set_rate(env: Env, rate: u64) {
+    require_admin(&env);
+    assert!(rate <= MAX_RATE, "rate exceeds maximum"); // ✅
+    env.storage().persistent().set(&DataKey::Rate, &rate);
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unchecked_math/README.md
+++ b/vulnerable/unchecked_math/README.md
@@ -1,0 +1,37 @@
+# `vulnerable/unchecked_math`
+
+## Vulnerability: Integer Overflow
+
+**Severity:** High
+
+## Description
+
+Staking reward calculations use raw `*` on `u64` values. When the stake amount or elapsed ledgers are large, the multiplication silently wraps to a small number, allowing an attacker to claim far less (or far more) than they are owed.
+
+## Exploit Scenario
+
+1. Attacker stakes a large amount and waits many ledgers.
+2. `claim_rewards` computes `stake * rate * elapsed` using unchecked arithmetic.
+3. The product overflows `u64`, wrapping to near zero — reward pool is effectively stolen or the attacker receives an inflated payout depending on wrap direction.
+
+## Vulnerable Code
+
+```rust
+let reward = stake * rate * elapsed; // ❌ silent overflow
+```
+
+## Secure Fix
+
+```rust
+let reward = stake
+    .checked_mul(rate)
+    .and_then(|v| v.checked_mul(elapsed))
+    .expect("reward overflow"); // ✅
+```
+
+See [`secure/secure_vault`](../../secure/secure_vault) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/underflow_transfer/README.md
+++ b/vulnerable/underflow_transfer/README.md
@@ -1,0 +1,39 @@
+# `vulnerable/underflow_transfer`
+
+## Vulnerability: Integer Underflow
+
+**Severity:** High
+
+## Description
+
+The transfer function subtracts the amount from the sender's balance using unchecked arithmetic. If the sender's balance is less than the amount, the subtraction wraps around to a very large positive number, giving the sender an enormous balance.
+
+## Exploit Scenario
+
+1. Attacker has a balance of 0.
+2. Attacker calls `transfer(attacker, victim, 1)`.
+3. `0 - 1` wraps to `u64::MAX` (or `i128::MAX` depending on type).
+4. Attacker now has an astronomically large balance.
+
+## Vulnerable Code
+
+```rust
+let new_balance = from_balance - amount; // ❌ wraps on underflow
+set_balance(&env, &from, new_balance);
+```
+
+## Secure Fix
+
+```rust
+let new_balance = from_balance
+    .checked_sub(amount)
+    .expect("insufficient balance"); // ✅
+assert!(new_balance >= 0, "insufficient balance");
+```
+
+No separate secure crate — see [`secure/secure_vault`](../../secure/secure_vault) for the pattern.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unprotected_admin/README.md
+++ b/vulnerable/unprotected_admin/README.md
@@ -1,0 +1,40 @@
+# `vulnerable/unprotected_admin`
+
+## Vulnerability: Privilege Escalation (Unprotected Admin Functions)
+
+**Severity:** Critical
+
+## Description
+
+`set_admin()` and `upgrade()` are callable by any address. An attacker can replace the admin with their own address or upgrade the contract WASM to malicious code, taking full control of the contract.
+
+## Exploit Scenario
+
+1. Attacker calls `set_admin(attacker_address)`.
+2. Contract stores the new admin without verifying the caller is the current admin.
+3. Attacker now controls all privileged functions including `upgrade()`.
+
+## Vulnerable Code
+
+```rust
+pub fn set_admin(env: Env, new_admin: Address) {
+    // ❌ Missing: require_admin(&env);
+    env.storage().persistent().set(&DataKey::Admin, &new_admin);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn set_admin(env: Env, new_admin: Address) {
+    require_admin(&env); // ✅
+    env.storage().persistent().set(&DataKey::Admin, &new_admin);
+}
+```
+
+See [`secure/protected_admin`](../../secure/protected_admin) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unprotected_burn/README.md
+++ b/vulnerable/unprotected_burn/README.md
@@ -1,0 +1,42 @@
+# `vulnerable/unprotected_burn`
+
+## Vulnerability: Unprotected Burn Function
+
+**Severity:** Critical
+
+## Description
+
+The `burn` function destroys tokens from any account without requiring authorisation from the account owner. Any caller can burn another user's tokens, destroying their funds.
+
+## Exploit Scenario
+
+1. Attacker calls `burn(victim, victim_balance)`.
+2. Contract burns the victim's tokens without checking the caller is the victim.
+3. Victim's entire balance is destroyed.
+
+## Vulnerable Code
+
+```rust
+pub fn burn(env: Env, account: Address, amount: i128) {
+    // ❌ Missing: account.require_auth();
+    let balance = get_balance(&env, &account);
+    set_balance(&env, &account, balance - amount);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn burn(env: Env, account: Address, amount: i128) {
+    account.require_auth(); // ✅
+    let balance = get_balance(&env, &account);
+    set_balance(&env, &account, balance.checked_sub(amount).unwrap());
+}
+```
+
+See [`secure/secure_burn`](../../secure/secure_burn) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unprotected_delete/README.md
+++ b/vulnerable/unprotected_delete/README.md
@@ -1,0 +1,40 @@
+# `vulnerable/unprotected_delete`
+
+## Vulnerability: Unprotected Storage Delete
+
+**Severity:** Critical
+
+## Description
+
+A function that wipes contract storage (or a user's data entry) is callable by any address without admin authorisation. An attacker can erase all contract state, effectively bricking the contract or wiping user balances.
+
+## Exploit Scenario
+
+1. Attacker calls `delete_all()` or `clear_user(victim)`.
+2. Contract removes storage entries without verifying the caller is the admin.
+3. All balances, configuration, or history is permanently deleted.
+
+## Vulnerable Code
+
+```rust
+pub fn delete_all(env: Env) {
+    // ❌ Missing: require_admin(&env);
+    env.storage().persistent().remove(&DataKey::Balances);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn delete_all(env: Env) {
+    require_admin(&env); // ✅
+    env.storage().persistent().remove(&DataKey::Balances);
+}
+```
+
+No separate secure crate — the fix is an inline admin auth check.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unprotected_emergency_withdraw/README.md
+++ b/vulnerable/unprotected_emergency_withdraw/README.md
@@ -1,0 +1,43 @@
+# `vulnerable/unprotected_emergency_withdraw`
+
+## Vulnerability: Unprotected Emergency Withdraw
+
+**Severity:** Critical
+
+## Description
+
+An emergency withdrawal function intended for admin use only is callable by any address. An attacker can drain the entire contract balance at any time by invoking the emergency exit.
+
+## Exploit Scenario
+
+1. Attacker calls `emergency_withdraw(attacker)`.
+2. Contract transfers all funds to the attacker without checking the caller is the admin.
+3. Contract is drained instantly.
+
+## Vulnerable Code
+
+```rust
+pub fn emergency_withdraw(env: Env, recipient: Address) {
+    // ❌ Missing: require_admin(&env);
+    let balance = get_pool_balance(&env);
+    token_client.transfer(&env.current_contract_address(), &recipient, &balance);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn emergency_withdraw(env: Env, recipient: Address) {
+    require_admin(&env); // ✅
+    // optionally also enforce a time-lock before allowing withdrawal
+    let balance = get_pool_balance(&env);
+    token_client.transfer(&env.current_contract_address(), &recipient, &balance);
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unprotected_fee_withdraw/README.md
+++ b/vulnerable/unprotected_fee_withdraw/README.md
@@ -1,0 +1,45 @@
+# `vulnerable/unprotected_fee_withdraw`
+
+## Vulnerability: Unprotected Fee Withdrawal
+
+**Severity:** Critical
+
+## Description
+
+The fee withdrawal function transfers accumulated fees to an arbitrary recipient without verifying the caller is the admin. Any address can drain the contract's fee balance to themselves.
+
+## Exploit Scenario
+
+1. Contract accumulates swap fees over time.
+2. Attacker calls `withdraw_fees(attacker)`.
+3. Contract transfers all fees to the attacker without an admin check.
+4. Legitimate fee recipients (protocol treasury) receive nothing.
+
+## Vulnerable Code
+
+```rust
+pub fn withdraw_fees(env: Env, recipient: Address) {
+    // ❌ Missing: require_admin(&env);
+    let fees = get_fees(&env);
+    set_fees(&env, 0);
+    token_client.transfer(&env.current_contract_address(), &recipient, &fees);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn withdraw_fees(env: Env, recipient: Address) {
+    require_admin(&env); // ✅
+    let fees = get_fees(&env);
+    set_fees(&env, 0);
+    token_client.transfer(&env.current_contract_address(), &recipient, &fees);
+}
+```
+
+See [`secure/protected_fee_withdraw`](../../secure/protected_fee_withdraw) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unprotected_mint/README.md
+++ b/vulnerable/unprotected_mint/README.md
@@ -1,0 +1,42 @@
+# `vulnerable/unprotected_mint`
+
+## Vulnerability: Unprotected Mint Function
+
+**Severity:** Critical
+
+## Description
+
+The `mint` function is callable by any address without admin authorisation. An attacker can mint an unlimited number of tokens to any address, inflating the supply and devaluing all existing token holders.
+
+## Exploit Scenario
+
+1. Attacker calls `mint(attacker, u64::MAX)`.
+2. Contract mints tokens without checking the caller is the admin.
+3. Attacker holds the entire token supply; all other holders are diluted to near zero.
+
+## Vulnerable Code
+
+```rust
+pub fn mint(env: Env, to: Address, amount: i128) {
+    // ❌ Missing: require_admin(&env);
+    let balance = get_balance(&env, &to);
+    set_balance(&env, &to, balance + amount);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn mint(env: Env, to: Address, amount: i128) {
+    require_admin(&env); // ✅
+    let balance = get_balance(&env, &to);
+    set_balance(&env, &to, balance + amount);
+}
+```
+
+No separate secure crate — the fix is an inline admin auth check.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unsafe_cast/README.md
+++ b/vulnerable/unsafe_cast/README.md
@@ -1,0 +1,35 @@
+# `vulnerable/unsafe_cast`
+
+## Vulnerability: Unsafe Integer Cast
+
+**Severity:** High
+
+## Description
+
+The contract casts between integer types (e.g. `u64 as i64` or `i128 as u64`) without range validation. A value that is valid in the source type may be negative or truncated in the target type, silently corrupting balances or reward calculations.
+
+## Exploit Scenario
+
+1. A balance of `u64::MAX` is cast to `i64`, producing `-1`.
+2. Subsequent arithmetic treats the balance as negative.
+3. Attacker exploits the corrupted value to withdraw more than they deposited.
+
+## Vulnerable Code
+
+```rust
+let signed_amount = raw_amount as i64; // ❌ wraps if raw_amount > i64::MAX
+```
+
+## Secure Fix
+
+```rust
+let signed_amount = i64::try_from(raw_amount)
+    .expect("amount exceeds i64::MAX"); // ✅
+```
+
+No separate secure crate — the fix is using `try_from` / `try_into` with explicit error handling.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/unsafe_storage/README.md
+++ b/vulnerable/unsafe_storage/README.md
@@ -1,0 +1,40 @@
+# `vulnerable/unsafe_storage`
+
+## Vulnerability: Unauthorised Storage Writes
+
+**Severity:** Critical
+
+## Description
+
+The KYC registry allows any caller to write to any account's storage slot. There is no check that the caller is the account being written to, so an attacker can overwrite another user's KYC status or data.
+
+## Exploit Scenario
+
+1. Attacker calls `set_kyc(victim, true)`.
+2. Contract writes to the victim's storage slot without verifying the caller is the victim or an authorised admin.
+3. Attacker can grant or revoke KYC status for any address.
+
+## Vulnerable Code
+
+```rust
+pub fn set_kyc(env: Env, account: Address, status: bool) {
+    // ❌ Missing: account.require_auth() or admin check
+    env.storage().persistent().set(&DataKey::Kyc(account), &status);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn set_kyc(env: Env, account: Address, status: bool) {
+    account.require_auth(); // ✅ or require_admin(&env) for admin-only writes
+    env.storage().persistent().set(&DataKey::Kyc(account), &status);
+}
+```
+
+See [`secure/protected_admin`](../../secure/protected_admin) for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/zero_admin/README.md
+++ b/vulnerable/zero_admin/README.md
@@ -1,0 +1,35 @@
+# `vulnerable/zero_admin`
+
+## Vulnerability: Zero Address Admin
+
+**Severity:** High
+
+## Description
+
+The contract allows the admin to be set to the zero address (all-zero bytes). If this happens, all admin-gated functions become permanently inaccessible because no one can sign as the zero address, effectively bricking the contract.
+
+## Exploit Scenario
+
+1. Admin accidentally or maliciously calls `set_admin(zero_address)`.
+2. The zero address is stored as admin.
+3. All admin functions (`upgrade`, `add_scanner`, etc.) are permanently locked.
+
+## Vulnerable Code
+
+```rust
+pub fn initialize(env: Env, admin: Address) {
+    // ❌ Missing: assert!(admin != zero_address, "admin cannot be zero address");
+    env.storage().persistent().set(&DataKey::Admin, &admin);
+}
+```
+
+## Secure Fix
+
+Validate the admin address is not the zero address at initialisation and in `set_admin`. On Soroban, use a sentinel check appropriate for the `Address` type.
+
+No separate secure crate — the fix is an inline guard.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/zero_deposit/README.md
+++ b/vulnerable/zero_deposit/README.md
@@ -1,0 +1,43 @@
+# `vulnerable/zero_deposit`
+
+## Vulnerability: Zero-Value Deposit
+
+**Severity:** Medium
+
+## Description
+
+The deposit function accepts `amount = 0` without rejecting it. An attacker can create storage entries at zero cost, wasting ledger space and potentially triggering edge cases in downstream logic that assumes deposits are positive.
+
+## Exploit Scenario
+
+1. Attacker calls `deposit(attacker, 0)` thousands of times.
+2. Each call writes a storage entry, consuming ledger resources.
+3. Legitimate users pay higher fees due to inflated state size.
+
+## Vulnerable Code
+
+```rust
+pub fn deposit(env: Env, account: Address, amount: i128) {
+    account.require_auth();
+    // ❌ Missing: assert!(amount > 0, "amount must be positive");
+    let balance = get_balance(&env, &account);
+    set_balance(&env, &account, balance + amount);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn deposit(env: Env, account: Address, amount: i128) {
+    account.require_auth();
+    assert!(amount > 0, "amount must be positive"); // ✅
+    // ...
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/zero_stake/README.md
+++ b/vulnerable/zero_stake/README.md
@@ -1,0 +1,38 @@
+# `vulnerable/zero_stake`
+
+## Vulnerability: Zero-Value Stake
+
+**Severity:** Medium
+
+## Description
+
+The staking contract accepts a stake of `0`. This creates a storage entry with no economic value, wastes ledger resources, and can cause division-by-zero errors in reward calculations that divide by total staked amount.
+
+## Exploit Scenario
+
+1. Attacker calls `stake(attacker, 0)` many times.
+2. Each call creates a storage entry and may increment a staker count.
+3. Reward calculations that divide by total stake encounter zero, causing a panic.
+
+## Vulnerable Code
+
+```rust
+pub fn stake(env: Env, staker: Address, amount: u64) {
+    staker.require_auth();
+    // ❌ Missing: assert!(amount > 0, "stake must be positive");
+    env.storage().persistent().set(&DataKey::Stake(staker), &amount);
+}
+```
+
+## Secure Fix
+
+```rust
+assert!(amount > 0, "stake must be positive"); // ✅
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)


### PR DESCRIPTION
closes #174 
closes #175 
closes #176 

Commit 1 — batch query, threat model, READMEs
  
  feat: add batch query, threat model, and per-crate vulnerability READMEs
  
  registry
  - Add get_latest_scans_batch(env, contracts: Vec<Address>) -> Vec<Option<ScanResult>>
  - Cap input at 20 addresses; panic "batch size exceeds maximum of 20" if exceeded
  - Return None for contracts with no scan history
  - Tests:
      test_batch_too_large_panics              — >20 addresses panics
      test_batch_returns_latest_and_none_for_unscanned — 3-contract batch, mixed results
      test_batch_empty_input_returns_empty     — empty input returns empty Vec
  
  docs/threat_model.md (185 lines)
  - Actors: Admin (High), Scanner (Medium), Staker (Low), Attacker (None)
  - Assets at Risk: token balances, admin keys, scan record integrity, allowances
  - Trust Boundaries: registry scanner allowlist, vault/staking account auth, admin EOA
  - Attack Vectors (38 in-scope, 4 out-of-scope): each mapped to a vulnerable crate
  - Mitigations: per-vector fix with reference to secure crate or inline secure.rs
  
  vulnerable/README_TEMPLATE.md
  - Standard template: Vulnerability Name, Severity, Description, Exploit Scenario,
    Vulnerable Code, Secure Fix, References
  
  vulnerable/*/README.md (39 files)
  - One README per vulnerable crate covering:
      admin_rugpull, allowance_not_decremented, call_depth, div_by_zero,
      double_claim, dust_griefing, flash_loan_no_check, instant_oracle,
      key_collision, leaky_events, missing_auth, missing_events, missing_ttl,
      negative_transfer, no_slippage, reentrancy, reinit_attack, replay_attack,
      scanner_impersonation, self_transfer, sensitive_storage, stale_oracle,
      string_admin, timestamp_lock, unbounded_storage, uncapped_rate,
      unchecked_math, underflow_transfer, unprotected_admin, unprotected_burn,
      unprotected_delete, unprotected_emergency_withdraw, unprotected_fee_withdraw,
      unprotected_mint, unsafe_cast, unsafe_storage, zero_admin, zero_deposit,
      zero_stake
  
  README.md
  - Vulnerable contracts table updated: all 39 rows now link to their crate README
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Commit 2 — secure_airdrop crate
  
  feat(secure): add secure_airdrop crate with Merkle-proof-based airdrop
  
  Implements a secure airdrop contract under secure/secure_airdrop that
  allows eligible addresses to claim tokens by submitting a Merkle proof
  against a root stored at initialisation.
  
  Security properties
  - One claim per address enforced via persistent storage; claimed flag
    written before token transfer (checks-effects-interactions)
  - Only the admin can fund the airdrop pool (require_auth enforced)
  - Claimant must authorise their own claim (require_auth on claimant)
  - Invalid proof panics before any state change occurs
  
  Contract API
  - initialize(admin, merkle_root, token)  — one-time setup, guarded
  - fund(amount)                           — admin-only token deposit
  - claim(claimant, amount, proof)         — auth + proof + transfer
  - get_claimed(address) -> bool           — read-only claimed status
  
  Merkle proof scheme
  - Leaf  = sha256(claimant.to_xdr() || amount.to_be_bytes())
  - Nodes = sha256(min(a,b) || max(a,b))  — canonical sorted pairing
  
  Tests
  - test_valid_proof_claims_successfully             — tokens transferred, address marked claimed
  - test_double_claim_panics                         — second claim panics "already claimed"
  - test_invalid_proof_rejected_before_state_change  — bad proof panics, storage unchanged
  
  Files
  - secure/secure_airdrop/Cargo.toml  — new crate (cdylib, soroban-sdk workspace dep)
  - secure/secure_airdrop/src/lib.rs  — contract + tests
  - Cargo.toml                        — registered in workspace members
  