### PR TITLE
feat: add vulnerable/escrow_balance_check crate (issue #146)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "registry",
     "vulnerable/expired_delegation",
     "vulnerable/uncapped_supply",
+    "vulnerable/escrow_balance_check",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/escrow_balance_check/Cargo.toml
+++ b/vulnerable/escrow_balance_check/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "escrow-balance-check"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban escrow contract that releases funds without checking the escrow balance"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/escrow_balance_check/src/lib.rs
+++ b/vulnerable/escrow_balance_check/src/lib.rs
@@ -1,0 +1,160 @@
+//! VULNERABLE: Missing Escrow Balance Check Before Release
+//!
+//! An escrow contract where the `release` function transfers funds to the
+//! beneficiary without first verifying that the escrow's recorded balance is
+//! sufficient to cover the release amount.
+//!
+//! VULNERABILITY: `release()` reads the stored escrow balance but never
+//! asserts it is >= `amount` before transferring. If the stored balance is
+//! stale or has been manipulated, the contract will subtract more than it
+//! holds, causing an arithmetic underflow in the internal ledger and leaving
+//! state permanently inconsistent.
+//!
+//! SECURE MIRROR: `secure::SecureEscrow` adds an explicit
+//! `if escrow_balance < amount { panic!("insufficient escrow balance") }`
+//! guard before the transfer and zeroes the entry on a full release.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Balance(u64),      // escrow_id -> locked amount
+    Beneficiary(u64),  // escrow_id -> beneficiary address
+}
+
+// ── Vulnerable contract ───────────────────────────────────────────────────────
+
+#[contract]
+pub struct VulnerableEscrow;
+
+#[contractimpl]
+impl VulnerableEscrow {
+    /// Initialise with an admin. Guards against re-initialisation.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Deposit `amount` into escrow slot `escrow_id` for `beneficiary`.
+    /// Requires admin auth (admin controls escrow creation).
+    pub fn deposit(env: Env, escrow_id: u64, beneficiary: Address, amount: i128) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(escrow_id))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(escrow_id), &(current + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Beneficiary(escrow_id), &beneficiary);
+    }
+
+    /// VULNERABLE: transfers `amount` to the beneficiary without checking
+    /// that the stored escrow balance is >= `amount`.
+    ///
+    /// # Vulnerability
+    /// Missing balance guard. Impact: the internal balance can underflow,
+    /// leaving the ledger in an inconsistent state.
+    pub fn release(env: Env, escrow_id: u64, amount: i128) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let beneficiary: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Beneficiary(escrow_id))
+            .expect("escrow not found");
+
+        let escrow_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(escrow_id))
+            .unwrap_or(0);
+
+        // ❌ Missing: if escrow_balance < amount { panic!("insufficient escrow balance") }
+
+        // Simulate the token transfer by adjusting the internal balance.
+        // In a real contract this would call token_client.transfer(...).
+        let new_balance = escrow_balance - amount; // underflows when amount > balance
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(escrow_id), &new_balance);
+
+        // Record the release destination (mirrors what a token transfer would do).
+        env.storage()
+            .persistent()
+            .set(&DataKey::Beneficiary(escrow_id), &beneficiary);
+    }
+
+    /// Returns the recorded balance for `escrow_id`.
+    pub fn escrow_balance(env: Env, escrow_id: u64) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(escrow_id))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, VulnerableEscrowClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, VulnerableEscrow);
+        let client = VulnerableEscrowClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        client.initialize(&admin);
+        (env, client, admin, beneficiary)
+    }
+
+    /// Demonstrates the bug: releasing more than the deposited balance does
+    /// NOT panic — the internal balance silently underflows to a negative value.
+    #[test]
+    fn test_release_exceeding_balance_does_not_revert() {
+        let (_env, client, _admin, beneficiary) = setup();
+        client.deposit(&1, &beneficiary, &500);
+
+        // Release 1000 when only 500 is held — should panic in a correct
+        // implementation, but the vulnerable contract allows it.
+        client.release(&1, &1000);
+
+        // Balance has underflowed to -500, demonstrating the bug.
+        assert_eq!(client.escrow_balance(&1), -500);
+    }
+
+    /// A valid release of the exact balance succeeds and zeroes the entry.
+    #[test]
+    fn test_valid_release_exact_balance_succeeds() {
+        let (_env, client, _admin, beneficiary) = setup();
+        client.deposit(&2, &beneficiary, &1000);
+        client.release(&2, &1000);
+        assert_eq!(client.escrow_balance(&2), 0);
+    }
+}

--- a/vulnerable/escrow_balance_check/src/secure.rs
+++ b/vulnerable/escrow_balance_check/src/secure.rs
@@ -1,0 +1,140 @@
+//! SECURE: Escrow Release With Balance Check
+//!
+//! Identical API to VulnerableEscrow but `release` guards against releasing
+//! more than the recorded escrow balance before adjusting state.
+
+use super::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureEscrow;
+
+#[contractimpl]
+impl SecureEscrow {
+    /// Initialise with an admin. Guards against re-initialisation.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    /// Deposit `amount` into escrow slot `escrow_id` for `beneficiary`.
+    pub fn deposit(env: Env, escrow_id: u64, beneficiary: Address, amount: i128) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(escrow_id))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(escrow_id), &(current + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Beneficiary(escrow_id), &beneficiary);
+    }
+
+    /// ✅ SECURE: checks that the escrow holds at least `amount` before
+    /// releasing. Uses `checked_sub` to prevent any arithmetic underflow.
+    pub fn release(env: Env, escrow_id: u64, amount: i128) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let beneficiary: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Beneficiary(escrow_id))
+            .expect("escrow not found");
+
+        let escrow_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(escrow_id))
+            .unwrap_or(0);
+
+        // ✅ FIX: explicit balance guard before any state mutation.
+        if escrow_balance < amount {
+            panic!("insufficient escrow balance");
+        }
+
+        // ✅ FIX: use checked_sub as a second line of defence against underflow.
+        let new_balance = escrow_balance
+            .checked_sub(amount)
+            .expect("insufficient escrow balance");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(escrow_id), &new_balance);
+
+        // Record the release destination (mirrors what a token transfer would do).
+        env.storage()
+            .persistent()
+            .set(&DataKey::Beneficiary(escrow_id), &beneficiary);
+    }
+
+    /// Returns the recorded balance for `escrow_id`.
+    pub fn escrow_balance(env: Env, escrow_id: u64) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(escrow_id))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, SecureEscrowClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureEscrow);
+        let client = SecureEscrowClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        client.initialize(&admin);
+        (env, client, admin, beneficiary)
+    }
+
+    /// After the fix, releasing more than the balance panics.
+    #[test]
+    #[should_panic(expected = "insufficient escrow balance")]
+    fn test_release_exceeding_balance_panics() {
+        let (_env, client, _admin, beneficiary) = setup();
+        client.deposit(&1, &beneficiary, &500);
+        // 1000 > 500 — must panic.
+        client.release(&1, &1000);
+    }
+
+    /// A valid release of the exact balance succeeds and zeroes the entry.
+    #[test]
+    fn test_valid_release_exact_balance_succeeds() {
+        let (_env, client, _admin, beneficiary) = setup();
+        client.deposit(&2, &beneficiary, &1000);
+        client.release(&2, &1000);
+        assert_eq!(client.escrow_balance(&2), 0);
+    }
+
+    /// A partial release reduces the balance correctly.
+    #[test]
+    fn test_partial_release_reduces_balance() {
+        let (_env, client, _admin, beneficiary) = setup();
+        client.deposit(&3, &beneficiary, &1000);
+        client.release(&3, &400);
+        assert_eq!(client.escrow_balance(&3), 600);
+    }
+}


### PR DESCRIPTION
closes #146 

## Summary

Adds the `vulnerable/escrow_balance_check` crate demonstrating a missing balance check before escrow release, along with a secure mirror that fixes it.

## Vulnerability (High Severity)

The `release()` function transfers funds to the beneficiary without verifying the escrow's recorded balance is sufficient. This allows the internal ledger to silently underflow to a negative value, leaving contract state permanently inconsistent.

```rust
// VULNERABLE — no guard before transfer
pub fn release(env: Env, escrow_id: u64, amount: i128) {
    let new_balance = escrow_balance - amount; // underflows when amount > balance
    env.storage().persistent().set(&DataKey::Balance(escrow_id), &new_balance);
}
