### PR TITLE
feat: add vulnerable/zero_stake_amount crate (issue #138)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "registry",
     "vulnerable/expired_delegation",
     "vulnerable/uncapped_supply",
+    "vulnerable/zero_stake_amount",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/zero_stake_amount/Cargo.toml
+++ b/vulnerable/zero_stake_amount/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zero-stake-amount"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban staking contract that accepts zero and negative stake amounts"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/zero_stake_amount/README.md
+++ b/vulnerable/zero_stake_amount/README.md
@@ -1,0 +1,39 @@
+# vulnerable/zero_stake_amount
+
+**Severity:** Medium
+
+## Description
+
+The `stake` function accepts any `i128` value including zero and negative numbers without validation. This allows callers to:
+
+- **Zero stake** — creates a persistent storage entry and emits an event without transferring any tokens, polluting ledger state and wasting resources.
+- **Negative stake** — silently underflows the staker's recorded balance, corrupting accounting.
+
+## Vulnerable Pattern
+
+```rust
+pub fn stake(env: Env, staker: Address, amount: i128) {
+    staker.require_auth();
+    // BUG: amount is never validated — zero and negative values accepted
+    let current: i128 = env.storage().persistent().get(&staker).unwrap_or(0);
+    env.storage().persistent().set(&staker, &(current + amount));
+}
+```
+
+## Fix
+
+Add a guard at the top of `stake` before any state mutation:
+
+```rust
+pub fn stake(env: Env, staker: Address, amount: i128) {
+    staker.require_auth();
+    // FIX: reject zero and negative amounts
+    if amount <= 0 {
+        panic!("amount must be positive");
+    }
+    let current: i128 = env.storage().persistent().get(&staker).unwrap_or(0);
+    env.storage().persistent().set(&staker, &(current + amount));
+}
+```
+
+The secure implementation lives in [`src/secure.rs`](src/secure.rs).

--- a/vulnerable/zero_stake_amount/src/lib.rs
+++ b/vulnerable/zero_stake_amount/src/lib.rs
@@ -1,0 +1,95 @@
+//! VULNERABLE: Stake Function Does Not Validate Amount > 0
+//!
+//! A staking contract where `stake()` accepts any i128 value including zero
+//! and negative numbers. A zero-amount stake creates a storage entry and
+//! emits an event without transferring any tokens, polluting ledger state and
+//! wasting resources. Negative amounts silently underflow the staker's
+//! recorded balance.
+//!
+//! VULNERABILITY: `stake()` never checks `amount > 0` before updating
+//! persistent storage, so callers can corrupt the ledger for free.
+//!
+//! SECURE MIRROR: `secure::SecureStaking` adds
+//! `if amount <= 0 { panic!("amount must be positive") }` at the top of
+//! `stake`, rejecting both zero and negative inputs.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Stake(Address),
+}
+
+// ── Vulnerable contract ───────────────────────────────────────────────────────
+
+#[contract]
+pub struct VulnerableStaking;
+
+#[contractimpl]
+impl VulnerableStaking {
+    /// VULNERABLE: amount is never validated — zero and negative values are
+    /// accepted, polluting storage and potentially underflowing balances.
+    ///
+    /// # Vulnerability
+    /// Missing `amount > 0` guard. Impact: free storage pollution and balance
+    /// underflow via negative stake amounts.
+    pub fn stake(env: Env, staker: Address, amount: i128) {
+        staker.require_auth();
+        // ❌ Missing: if amount <= 0 { panic!("amount must be positive") }
+        let key = DataKey::Stake(staker.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
+    }
+
+    /// Returns the staked balance for `staker`.
+    pub fn balance(env: Env, staker: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Stake(staker))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, VulnerableStakingClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, VulnerableStaking);
+        let client = VulnerableStakingClient::new(&env, &id);
+        let staker = Address::generate(&env);
+        (env, client, staker)
+    }
+
+    /// Demonstrates the bug: staking zero succeeds and creates a storage entry.
+    /// A correct implementation should panic here.
+    #[test]
+    fn test_stake_zero_amount_succeeds() {
+        let (_env, client, staker) = setup();
+        // Should panic in a fixed contract, but the vulnerable one allows it.
+        client.stake(&staker, &0);
+        // Storage entry was created with a zero balance — wasted ledger space.
+        assert_eq!(client.balance(&staker), 0);
+    }
+
+    /// Demonstrates the bug: staking a negative amount does not revert and
+    /// silently underflows the staker's recorded balance.
+    #[test]
+    fn test_stake_negative_amount_does_not_revert() {
+        let (_env, client, staker) = setup();
+        client.stake(&staker, &1000);
+        // Negative stake silently reduces the balance — this is the bug.
+        client.stake(&staker, &-500);
+        assert_eq!(client.balance(&staker), 500);
+    }
+}

--- a/vulnerable/zero_stake_amount/src/secure.rs
+++ b/vulnerable/zero_stake_amount/src/secure.rs
@@ -1,0 +1,75 @@
+//! SECURE: Staking With Amount Validation
+//!
+//! Identical API to VulnerableStaking but `stake` rejects zero and negative
+//! amounts before touching persistent storage.
+
+use super::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureStaking;
+
+#[contractimpl]
+impl SecureStaking {
+    /// ✅ SECURE: rejects zero and negative amounts before updating storage.
+    pub fn stake(env: Env, staker: Address, amount: i128) {
+        staker.require_auth();
+        // ✅ FIX: amount must be strictly positive.
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+        let key = DataKey::Stake(staker.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
+    }
+
+    /// Returns the staked balance for `staker`.
+    pub fn balance(env: Env, staker: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Stake(staker))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, SecureStakingClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureStaking);
+        let client = SecureStakingClient::new(&env, &id);
+        let staker = Address::generate(&env);
+        (env, client, staker)
+    }
+
+    /// After the fix, staking zero panics.
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_stake_zero_panics() {
+        let (_env, client, staker) = setup();
+        client.stake(&staker, &0);
+    }
+
+    /// After the fix, staking a negative amount panics.
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_stake_negative_panics() {
+        let (_env, client, staker) = setup();
+        client.stake(&staker, &-1);
+    }
+
+    /// A valid positive stake succeeds and accumulates correctly.
+    #[test]
+    fn test_valid_stake_succeeds() {
+        let (_env, client, staker) = setup();
+        client.stake(&staker, &500);
+        client.stake(&staker, &300);
+        assert_eq!(client.balance(&staker), 800);
+    }
+}


### PR DESCRIPTION

Closes #138 

Adds the `vulnerable/zero_stake_amount` crate demonstrating a staking contract that accepts zero and negative amounts without validation, along with a secure mirror that fixes it.

## Vulnerability (Medium Severity)

The `stake()` function never validates that `amount > 0` before writing to persistent storage. This allows:

- **Zero stake** — creates a storage entry and emits an event without transferring any tokens, polluting ledger state and wasting resources.
- **Negative stake** — silently underflows the staker's recorded balance, corrupting accounting.

## Fix (secure::SecureStaking)

Add a guard at the top of `stake` before any state mutation:

if amount <= 0 { panic!("amount must be positive") }

## Tests (5 passing)

| Test | Contract | Purpose |
|------|----------|---------|
| `test_stake_zero_amount_succeeds` | Vulnerable | Demonstrates the bug — zero stake creates storage entry |
| `test_stake_negative_amount_does_not_revert` | Vulnerable | Demonstrates the bug — negative stake underflows balance |
| `test_stake_zero_panics` | Secure | Fix correctly rejects zero amount |
| `test_stake_negative_panics` | Secure | Fix correctly rejects negative amount |
| `test_valid_stake_succeeds` | Secure | Valid positive stakes accumulate correctly |

## Files Changed

- `vulnerable/zero_stake_amount/Cargo.toml` — new crate manifest
- `vulnerable/zero_stake_amount/README.md` — documents the vulnerability and fix
- `vulnerable/zero_stake_amount/src/lib.rs` — vulnerable contract + bug-demo tests
- `vulnerable/zero_stake_amount/src/secure.rs` — secure mirror with fix + tests
- `Cargo.toml` — added crate to workspace members
