### PR TITLE
Feature/new vulnerability crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ members = [
     "vulnerable/expired_delegation",
     "vulnerable/uncapped_supply",
     "vulnerable/silent_admin_change",
+    "vulnerable/oracle_price_scale_mismatch",
+    "vulnerable/mixed_collateral_decimals",
+    "vulnerable/signed_unsigned_wrap",
+    "vulnerable/abs_min_overflow",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/abs_min_overflow/Cargo.toml
+++ b/vulnerable/abs_min_overflow/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "abs-min-overflow"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract: unchecked abs() on i128::MIN overflows — risk module computes wrong debt delta"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/abs_min_overflow/src/lib.rs
+++ b/vulnerable/abs_min_overflow/src/lib.rs
@@ -1,0 +1,121 @@
+//! VULNERABLE: Absolute-Value Overflow on i128::MIN
+//!
+//! A risk module that computes the absolute debt delta with `i128::abs()`.
+//! `i128::MIN.abs()` cannot be represented as a positive `i128` — in debug
+//! builds Rust panics; in release builds with `overflow-checks = true` it also
+//! panics.  Without that flag the result silently wraps back to `i128::MIN`,
+//! a large negative number that corrupts any downstream solvency check.
+//!
+//! VULNERABILITY: `i128::MIN` passed through an unchecked `abs()` call.
+//!
+//! SEVERITY: Medium
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    DebtDelta(Address),
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct RiskModule;
+
+#[contractimpl]
+impl RiskModule {
+    /// VULNERABLE: stores `abs(delta)` without guarding against `i128::MIN`.
+    /// `i128::MIN.abs()` overflows — panics with overflow-checks or wraps to
+    /// `i128::MIN` without them, storing a negative "absolute" value.
+    pub fn record_delta(env: Env, user: Address, delta: i128) {
+        user.require_auth();
+        // ❌ Unchecked abs — panics or wraps on i128::MIN.
+        let abs_delta = delta.abs();
+        env.storage()
+            .persistent()
+            .set(&DataKey::DebtDelta(user), &abs_delta);
+    }
+
+    pub fn get_delta(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DebtDelta(user))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, Address, RiskModuleClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, RiskModule);
+        let client = RiskModuleClient::new(&env, &id);
+        let user = Address::generate(&env);
+        (env, user, client)
+    }
+
+    /// Normal negative delta: abs() works correctly for values other than MIN.
+    #[test]
+    fn test_normal_negative_delta_abs_correct() {
+        let (env, user, client) = setup();
+        client.record_delta(&user, &-42_i128);
+        assert_eq!(client.get_delta(&user), 42_i128);
+    }
+
+    /// Demonstrates the vulnerability: i128::MIN.abs() panics (overflow-checks on)
+    /// or wraps to i128::MIN (overflow-checks off), corrupting the stored delta.
+    #[test]
+    #[should_panic]
+    fn test_vulnerable_i128_min_panics_or_wraps() {
+        let (env, user, client) = setup();
+        // ❌ i128::MIN has no positive representation in i128 — this overflows.
+        client.record_delta(&user, &i128::MIN);
+    }
+
+    /// Boundary: i128::MIN + 1 is the most-negative value abs() can handle.
+    #[test]
+    fn test_boundary_i128_min_plus_one_is_safe() {
+        let (env, user, client) = setup();
+        client.record_delta(&user, &(i128::MIN + 1));
+        assert_eq!(client.get_delta(&user), i128::MAX);
+    }
+
+    // ── secure mirror ────────────────────────────────────────────────────────
+
+    /// Secure path rejects i128::MIN before calling abs().
+    #[test]
+    #[should_panic(expected = "delta out of range")]
+    fn test_secure_rejects_i128_min() {
+        use crate::secure::SecureRiskClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureRisk);
+        let client = SecureRiskClient::new(&env, &id);
+        let user = Address::generate(&env);
+        client.record_delta(&user, &i128::MIN);
+    }
+
+    /// Secure path correctly handles a normal negative delta.
+    #[test]
+    fn test_secure_normal_delta_stored_correctly() {
+        use crate::secure::SecureRiskClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureRisk);
+        let client = SecureRiskClient::new(&env, &id);
+        let user = Address::generate(&env);
+        client.record_delta(&user, &-100_i128);
+        assert_eq!(client.get_delta(&user), 100_i128);
+    }
+}

--- a/vulnerable/abs_min_overflow/src/secure.rs
+++ b/vulnerable/abs_min_overflow/src/secure.rs
@@ -1,0 +1,30 @@
+//! SECURE mirror: reject i128::MIN before calling abs(), or use checked_abs().
+//!
+//! `i128::checked_abs()` returns `None` for `i128::MIN`; we treat that as an
+//! explicit error rather than letting it panic or silently wrap.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureRisk;
+
+#[contractimpl]
+impl SecureRisk {
+    /// ✅ Uses `checked_abs()` and panics with a clear message on i128::MIN.
+    pub fn record_delta(env: Env, user: Address, delta: i128) {
+        user.require_auth();
+        // ✅ checked_abs returns None for i128::MIN — explicit rejection.
+        let abs_delta = delta.checked_abs().expect("delta out of range");
+        env.storage()
+            .persistent()
+            .set(&DataKey::DebtDelta(user), &abs_delta);
+    }
+
+    pub fn get_delta(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DebtDelta(user))
+            .unwrap_or(0)
+    }
+}

--- a/vulnerable/mixed_collateral_decimals/Cargo.toml
+++ b/vulnerable/mixed_collateral_decimals/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mixed-collateral-decimals"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract: collateral summed in raw token units without decimal normalisation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/mixed_collateral_decimals/src/lib.rs
+++ b/vulnerable/mixed_collateral_decimals/src/lib.rs
@@ -1,0 +1,200 @@
+//! VULNERABLE: Mixed Collateral Decimals
+//!
+//! A lending contract that sums collateral from different tokens by adding
+//! their raw token units directly.  Token A has 6 decimals and Token B has
+//! 18 decimals.  One unit of Token B (1e18 raw) is treated as 1e12× more
+//! valuable than one unit of Token A (1e6 raw), even if their USD prices are
+//! identical, allowing a borrower to unlock enormous borrowing power with a
+//! dust deposit of a high-decimal token.
+//!
+//! VULNERABILITY: Collateral aggregation adds raw token units across assets
+//! without normalising by each token's decimal count and oracle price.
+//!
+//! SEVERITY: Critical
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+
+pub mod secure;
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    /// Oracle price for a token symbol (USD, 1e6 scale).
+    Price(Symbol),
+    /// Decimal count for a token symbol.
+    Decimals(Symbol),
+    /// Aggregated raw collateral for a user (sum of raw units, NOT normalised).
+    Collateral(Address),
+    /// Debt taken by a user (USD, 1e6 scale).
+    Debt(Address),
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct LendingPool;
+
+#[contractimpl]
+impl LendingPool {
+    /// Register a token with its USD price (1e6 scale) and decimal count.
+    pub fn register_token(env: Env, token: Symbol, price_usd: i128, decimals: u32) {
+        env.storage().persistent().set(&DataKey::Price(token.clone()), &price_usd);
+        env.storage().persistent().set(&DataKey::Decimals(token), &decimals);
+    }
+
+    /// Deposit `amount` raw token units of `token` as collateral for `user`.
+    /// VULNERABLE: raw units are added directly without decimal normalisation.
+    pub fn deposit(env: Env, user: Address, token: Symbol, amount: i128) {
+        user.require_auth();
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        // ❌ Raw units added — a token with 18 decimals inflates value vs 6-decimal token.
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user), &(current + amount));
+    }
+
+    /// Borrow `amount` USD (1e6 scale) against deposited collateral.
+    /// VULNERABLE: solvency check compares raw collateral units to USD debt.
+    pub fn borrow(env: Env, user: Address, amount: i128) -> i128 {
+        user.require_auth();
+        let collateral: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        let debt: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Debt(user.clone()))
+            .unwrap_or(0);
+        // ❌ Raw collateral units compared directly to USD debt amount.
+        assert!(collateral >= debt + amount, "undercollateralised");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Debt(user), &(debt + amount));
+        amount
+    }
+
+    pub fn get_collateral(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Collateral(user))
+            .unwrap_or(0)
+    }
+
+    pub fn get_debt(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Debt(user))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, Address, LendingPoolClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, LendingPool);
+        let client = LendingPoolClient::new(&env, &id);
+        let user = Address::generate(&env);
+        (env, user, client)
+    }
+
+    /// Demonstrates the vulnerability: depositing 1 raw unit of an 18-decimal
+    /// token (worth $1e-18 USD) inflates collateral to 1, which is treated as
+    /// 1 USD (1e6 scale) — enabling overborrowing.
+    #[test]
+    fn test_vulnerable_inflated_borrow_from_high_decimal_token() {
+        let (env, user, client) = setup();
+
+        let token_a = symbol_short!("USDC"); // 6 decimals, $1 per token
+        let token_b = symbol_short!("WBTC"); // 18 decimals, $1 per token (same price)
+
+        // $1.00 per token at 1e6 USD scale = 1_000_000
+        client.register_token(&token_a, &1_000_000_i128, &6);
+        client.register_token(&token_b, &1_000_000_i128, &18);
+
+        // Deposit 1 raw unit of the 18-decimal token.
+        // Real USD value = 1 / 1e18 * $1 ≈ $0 (negligible).
+        // Vulnerable stored collateral = 1 (raw unit).
+        client.deposit(&user, &token_b, &1_i128);
+
+        // ❌ Collateral stored as raw 1, which passes the solvency check for
+        // a borrow of 1 USD unit — but the real collateral is worth ~$0.
+        let collateral = client.get_collateral(&user);
+        assert_eq!(collateral, 1_i128);
+
+        // Attacker borrows 1 USD unit backed by essentially zero collateral.
+        let borrowed = client.borrow(&user, &1_i128);
+        assert_eq!(borrowed, 1_i128);
+    }
+
+    /// Boundary: depositing 1 unit of a 6-decimal token ($1) and borrowing
+    /// exactly 1_000_000 (= $1 at 1e6 scale) should fail because raw units
+    /// (1) < debt (1_000_000) — shows the inconsistency in the vulnerable model.
+    #[test]
+    #[should_panic(expected = "undercollateralised")]
+    fn test_boundary_6_decimal_token_cannot_borrow_usd_amount() {
+        let (env, user, client) = setup();
+        let token_a = symbol_short!("USDC");
+        client.register_token(&token_a, &1_000_000_i128, &6);
+        // Deposit 1 raw unit of 6-decimal token (= $0.000001).
+        client.deposit(&user, &token_a, &1_i128);
+        // Trying to borrow $1 (1_000_000 at 1e6 scale) must fail.
+        client.borrow(&user, &1_000_000_i128);
+    }
+
+    // ── secure mirror ────────────────────────────────────────────────────────
+
+    /// Secure path normalises collateral to USD (1e6 scale) before storing,
+    /// so the 18-decimal dust deposit cannot unlock any meaningful borrow.
+    #[test]
+    #[should_panic(expected = "undercollateralised")]
+    fn test_secure_rejects_dust_deposit_overborrow() {
+        use crate::secure::SecurePoolClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecurePool);
+        let client = SecurePoolClient::new(&env, &id);
+        let user = Address::generate(&env);
+
+        let token_b = symbol_short!("WBTC");
+        client.register_token(&token_b, &1_000_000_i128, &18);
+        // 1 raw unit of 18-decimal token → normalised USD value rounds to 0.
+        client.deposit(&user, &token_b, &1_i128);
+        // Must panic: normalised collateral is 0.
+        client.borrow(&user, &1_i128);
+    }
+
+    /// Secure path: depositing a meaningful amount of a 6-decimal token
+    /// correctly computes USD collateral and allows a proportional borrow.
+    #[test]
+    fn test_secure_allows_valid_borrow_after_normalisation() {
+        use crate::secure::SecurePoolClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecurePool);
+        let client = SecurePoolClient::new(&env, &id);
+        let user = Address::generate(&env);
+
+        let token_a = symbol_short!("USDC");
+        // $1 per token, 6 decimals → 1_000_000 raw units = $1.00 (1_000_000 at 1e6)
+        client.register_token(&token_a, &1_000_000_i128, &6);
+        client.deposit(&user, &token_a, &1_000_000_i128); // deposit $1
+        // Borrow $0.50 — within collateral.
+        let borrowed = client.borrow(&user, &500_000_i128);
+        assert_eq!(borrowed, 500_000_i128);
+    }
+}

--- a/vulnerable/mixed_collateral_decimals/src/secure.rs
+++ b/vulnerable/mixed_collateral_decimals/src/secure.rs
@@ -1,0 +1,70 @@
+//! SECURE mirror: normalise collateral to USD (1e6 scale) using token decimals
+//! and oracle price before summing across assets.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct SecurePool;
+
+/// Convert `raw_amount` token units to USD at 1e6 scale.
+/// `price_usd` is the token price in USD at 1e6 scale (e.g. 1_000_000 = $1).
+/// `decimals` is the token's decimal count.
+fn to_usd(raw_amount: i128, price_usd: i128, decimals: u32) -> i128 {
+    // USD value = raw_amount * price_usd / 10^decimals
+    // We keep 1e6 scale: divide by 10^decimals, multiply by price_usd already at 1e6.
+    let divisor = 10_i128.pow(decimals);
+    raw_amount * price_usd / divisor
+}
+
+#[contractimpl]
+impl SecurePool {
+    pub fn register_token(env: Env, token: Symbol, price_usd: i128, decimals: u32) {
+        env.storage().persistent().set(&DataKey::Price(token.clone()), &price_usd);
+        env.storage().persistent().set(&DataKey::Decimals(token), &decimals);
+    }
+
+    pub fn deposit(env: Env, user: Address, token: Symbol, amount: i128) {
+        user.require_auth();
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price(token.clone()))
+            .unwrap_or(0);
+        let decimals: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Decimals(token))
+            .unwrap_or(0);
+        // ✅ Normalise to USD (1e6 scale) before adding to collateral.
+        let usd_value = to_usd(amount, price, decimals);
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user), &(current + usd_value));
+    }
+
+    pub fn borrow(env: Env, user: Address, amount: i128) -> i128 {
+        user.require_auth();
+        let collateral: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        let debt: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Debt(user.clone()))
+            .unwrap_or(0);
+        // ✅ Both collateral and debt are in USD (1e6 scale) — apples-to-apples.
+        assert!(collateral >= debt + amount, "undercollateralised");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Debt(user), &(debt + amount));
+        amount
+    }
+}

--- a/vulnerable/oracle_price_scale_mismatch/Cargo.toml
+++ b/vulnerable/oracle_price_scale_mismatch/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "oracle-price-scale-mismatch"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract: oracle price exponent ignored — collateral inflated by orders of magnitude"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/oracle_price_scale_mismatch/src/lib.rs
+++ b/vulnerable/oracle_price_scale_mismatch/src/lib.rs
@@ -1,0 +1,202 @@
+//! VULNERABLE: Oracle Price Scale Mismatch
+//!
+//! A lending market that reads prices from two oracles but ignores the
+//! `exponent` field each oracle reports alongside its price.  One feed uses
+//! a 1e7 scale (exponent = -7) and another uses a 1e9 scale (exponent = -9).
+//! Because the contract treats both raw values as if they share the same unit,
+//! collateral denominated in the 1e9 feed appears 100× larger than it really
+//! is, letting a borrower drain the pool.
+//!
+//! VULNERABILITY: Oracle price exponent / decimals field is ignored before
+//! solvency checks.
+//!
+//! SEVERITY: Critical
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+pub mod secure;
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    /// Raw price stored by the oracle feed (no exponent applied).
+    Price(Symbol),
+    /// Exponent reported by the oracle feed (e.g. -7 means value / 1e7).
+    Exponent(Symbol),
+    /// Collateral deposited by a user (raw token units).
+    Collateral(Address),
+    /// Debt taken by a user (in normalised USD units, 1e7 scale).
+    Debt(Address),
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct LendingMarket;
+
+#[contractimpl]
+impl LendingMarket {
+    /// Register an oracle feed with its raw price and exponent.
+    /// `exponent` is the negative power of 10 (e.g. 7 means price / 1e7).
+    pub fn set_oracle(env: Env, feed: Symbol, price: i128, exponent: u32) {
+        env.storage().persistent().set(&DataKey::Price(feed.clone()), &price);
+        env.storage().persistent().set(&DataKey::Exponent(feed), &exponent);
+    }
+
+    /// Deposit collateral for `user` denominated in `feed` units.
+    pub fn deposit(env: Env, user: Address, feed: Symbol, amount: i128) {
+        user.require_auth();
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        // ❌ Raw token units stored without normalising by oracle exponent.
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price(feed))
+            .unwrap_or(0);
+        let collateral_value = amount * price; // BUG: exponent ignored
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user), &(current + collateral_value));
+    }
+
+    /// Borrow `amount` (normalised USD, 1e7 scale) against deposited collateral.
+    /// VULNERABLE: collateral value was computed without normalising the exponent,
+    /// so a 1e9-scale feed inflates collateral 100× vs a 1e7-scale feed.
+    pub fn borrow(env: Env, user: Address, amount: i128) -> i128 {
+        user.require_auth();
+        let collateral: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        let debt: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Debt(user.clone()))
+            .unwrap_or(0);
+        // ❌ Solvency check uses raw (un-normalised) collateral value.
+        assert!(collateral >= debt + amount, "undercollateralised");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Debt(user), &(debt + amount));
+        amount
+    }
+
+    pub fn get_collateral(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Collateral(user))
+            .unwrap_or(0)
+    }
+
+    pub fn get_debt(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Debt(user))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, Address, LendingMarketClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, LendingMarket);
+        let client = LendingMarketClient::new(&env, &id);
+        let user = Address::generate(&env);
+        (env, user, client)
+    }
+
+    /// Demonstrates the vulnerability: a 1e9-scale feed inflates collateral
+    /// 100× compared to a 1e7-scale feed, allowing overborrowing.
+    #[test]
+    fn test_vulnerable_overborrow_with_1e9_feed() {
+        let (env, user, client) = setup();
+
+        let feed_1e7 = symbol_short!("f7");
+        let feed_1e9 = symbol_short!("f9");
+
+        // 1e7 feed: price = 1_000_0000 (= $1.00 at 1e7 scale)
+        client.set_oracle(&feed_1e7, &10_000_000_i128, &7);
+        // 1e9 feed: price = 1_000_000_000 (= $1.00 at 1e9 scale, but 100× raw)
+        client.set_oracle(&feed_1e9, &1_000_000_000_i128, &9);
+
+        // Deposit 1 unit via the 1e9 feed.
+        // Correct USD value = 1 * 1_000_000_000 / 1e9 = $1 (at 1e7 scale → 10_000_000)
+        // Vulnerable value  = 1 * 1_000_000_000        = 1_000_000_000 (100× inflated)
+        client.deposit(&user, &feed_1e9, &1_i128);
+
+        let collateral = client.get_collateral(&user);
+        // ❌ Collateral is 100× what it should be.
+        assert_eq!(collateral, 1_000_000_000_i128);
+
+        // Attacker borrows 100× more than their real collateral allows.
+        let borrowed = client.borrow(&user, &900_000_000_i128);
+        assert_eq!(borrowed, 900_000_000_i128);
+    }
+
+    /// Boundary: with a correctly-scaled 1e7 feed the same 1-unit deposit
+    /// only supports a proportionally smaller borrow.
+    #[test]
+    fn test_boundary_1e7_feed_correct_scale() {
+        let (env, user, client) = setup();
+        let feed_1e7 = symbol_short!("f7");
+        client.set_oracle(&feed_1e7, &10_000_000_i128, &7);
+        client.deposit(&user, &feed_1e7, &1_i128);
+        // Collateral = 1 * 10_000_000 = 10_000_000 (correct for 1e7 scale)
+        assert_eq!(client.get_collateral(&user), 10_000_000_i128);
+        // Can borrow up to 10_000_000, not 1_000_000_000.
+        client.borrow(&user, &10_000_000_i128);
+    }
+
+    // ── secure mirror ────────────────────────────────────────────────────────
+
+    /// Secure path normalises both feeds to the same scale before solvency check.
+    #[test]
+    #[should_panic(expected = "undercollateralised")]
+    fn test_secure_rejects_overborrow() {
+        use crate::secure::SecureLendingClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureLending);
+        let client = SecureLendingClient::new(&env, &id);
+        let user = Address::generate(&env);
+
+        let feed_1e9 = symbol_short!("f9");
+        client.set_oracle(&feed_1e9, &1_000_000_000_i128, &9);
+        // Deposit 1 unit via 1e9 feed → normalised value = 10_000_000 (1e7 scale)
+        client.deposit(&user, &feed_1e9, &1_i128);
+        // Attempting to borrow 900_000_000 against 10_000_000 collateral must panic.
+        client.borrow(&user, &900_000_000_i128);
+    }
+
+    /// Secure path allows a borrow within the normalised collateral limit.
+    #[test]
+    fn test_secure_allows_valid_borrow() {
+        use crate::secure::SecureLendingClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureLending);
+        let client = SecureLendingClient::new(&env, &id);
+        let user = Address::generate(&env);
+
+        let feed_1e9 = symbol_short!("f9");
+        client.set_oracle(&feed_1e9, &1_000_000_000_i128, &9);
+        client.deposit(&user, &feed_1e9, &1_i128);
+        // Normalised collateral = 10_000_000; borrow within limit.
+        let borrowed = client.borrow(&user, &5_000_000_i128);
+        assert_eq!(borrowed, 5_000_000_i128);
+    }
+}

--- a/vulnerable/oracle_price_scale_mismatch/src/secure.rs
+++ b/vulnerable/oracle_price_scale_mismatch/src/secure.rs
@@ -1,0 +1,77 @@
+//! SECURE mirror: normalise oracle price by its exponent before solvency checks.
+//!
+//! Every price is scaled to a common 1e7 base before being stored as collateral
+//! value, so feeds with different exponents cannot inflate borrowing power.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+
+#[contract]
+pub struct SecureLending;
+
+/// Scale `price` (raw oracle value) down to a 1e7 base using `exponent`.
+/// `exponent` is the negative power of 10 the oracle uses (e.g. 9 → divide by 1e9,
+/// then multiply by 1e7 → net divide by 100).
+fn normalise(price: i128, exponent: u32) -> i128 {
+    // Target scale is 1e7.  If exponent > 7 we divide; if < 7 we multiply.
+    if exponent >= 7 {
+        let divisor = 10_i128.pow(exponent - 7);
+        price / divisor
+    } else {
+        let multiplier = 10_i128.pow(7 - exponent);
+        price * multiplier
+    }
+}
+
+#[contractimpl]
+impl SecureLending {
+    pub fn set_oracle(env: Env, feed: Symbol, price: i128, exponent: u32) {
+        env.storage().persistent().set(&DataKey::Price(feed.clone()), &price);
+        env.storage().persistent().set(&DataKey::Exponent(feed), &exponent);
+    }
+
+    pub fn deposit(env: Env, user: Address, feed: Symbol, amount: i128) {
+        user.require_auth();
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price(feed.clone()))
+            .unwrap_or(0);
+        let exponent: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Exponent(feed))
+            .unwrap_or(7);
+        // ✅ Normalise to 1e7 scale before computing collateral value.
+        let unit_value = normalise(price, exponent);
+        let collateral_value = amount * unit_value;
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Collateral(user), &(current + collateral_value));
+    }
+
+    pub fn borrow(env: Env, user: Address, amount: i128) -> i128 {
+        user.require_auth();
+        let collateral: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user.clone()))
+            .unwrap_or(0);
+        let debt: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Debt(user.clone()))
+            .unwrap_or(0);
+        // ✅ Solvency check uses normalised collateral value.
+        assert!(collateral >= debt + amount, "undercollateralised");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Debt(user), &(debt + amount));
+        amount
+    }
+}

--- a/vulnerable/signed_unsigned_wrap/Cargo.toml
+++ b/vulnerable/signed_unsigned_wrap/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "signed-unsigned-wrap"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract: signed i128 cast to u128 before positivity check — negative inputs become huge values"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/signed_unsigned_wrap/src/lib.rs
+++ b/vulnerable/signed_unsigned_wrap/src/lib.rs
@@ -1,0 +1,119 @@
+//! VULNERABLE: Signed-to-Unsigned Wrap
+//!
+//! A deposit contract that accepts an `i128` amount but casts it to `u128`
+//! with `as u128` before the positivity check.  A negative `i128` value
+//! reinterprets its two's-complement bit pattern as a huge `u128`, so the
+//! `amount > 0` guard (applied after the cast) always passes, and the
+//! corrupted value is stored in the balance.
+//!
+//! VULNERABILITY: Signed input is cast to unsigned before positivity check.
+//!
+//! SEVERITY: High
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Balance(Address),
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct DepositVault;
+
+#[contractimpl]
+impl DepositVault {
+    /// VULNERABLE: casts `amount` (i128) to u128 before checking positivity.
+    /// A negative i128 becomes a huge u128 via two's-complement reinterpretation,
+    /// bypassing the `> 0` guard and storing a corrupted balance.
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        // ❌ Cast happens before the guard — negative values wrap to huge u128.
+        let unsigned = amount as u128;
+        assert!(unsigned > 0, "amount must be positive");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(user), &unsigned);
+    }
+
+    pub fn get_balance(env: Env, user: Address) -> u128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(user))
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, Address, DepositVaultClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, DepositVault);
+        let client = DepositVaultClient::new(&env, &id);
+        let user = Address::generate(&env);
+        (env, user, client)
+    }
+
+    /// Demonstrates the vulnerability: a negative amount passes the guard and
+    /// is stored as a huge u128 value.
+    #[test]
+    fn test_vulnerable_negative_amount_stored_as_huge_u128() {
+        let (env, user, client) = setup();
+
+        // -1_i128 as u128 == u128::MAX (two's-complement wrap).
+        client.deposit(&user, &-1_i128);
+        let balance = client.get_balance(&user);
+        assert_eq!(balance, u128::MAX, "negative i128 wrapped to u128::MAX");
+    }
+
+    /// Boundary: i128::MIN as u128 is also a huge positive value (2^127).
+    #[test]
+    fn test_boundary_i128_min_wraps_to_large_u128() {
+        let (env, user, client) = setup();
+        client.deposit(&user, &i128::MIN);
+        let balance = client.get_balance(&user);
+        // i128::MIN as u128 == 2^127
+        assert_eq!(balance, i128::MIN as u128);
+        assert!(balance > u128::MAX / 2, "wrapped value is enormous");
+    }
+
+    // ── secure mirror ────────────────────────────────────────────────────────
+
+    /// Secure path rejects negative amounts before any cast.
+    #[test]
+    #[should_panic(expected = "amount must be positive")]
+    fn test_secure_rejects_negative_amount() {
+        use crate::secure::SecureVaultClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureVault);
+        let client = SecureVaultClient::new(&env, &id);
+        let user = Address::generate(&env);
+        client.deposit(&user, &-1_i128);
+    }
+
+    /// Secure path accepts a valid positive amount.
+    #[test]
+    fn test_secure_accepts_positive_amount() {
+        use crate::secure::SecureVaultClient;
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureVault);
+        let client = SecureVaultClient::new(&env, &id);
+        let user = Address::generate(&env);
+        client.deposit(&user, &1_000_i128);
+        assert_eq!(client.get_balance(&user), 1_000_u128);
+    }
+}

--- a/vulnerable/signed_unsigned_wrap/src/secure.rs
+++ b/vulnerable/signed_unsigned_wrap/src/secure.rs
@@ -1,0 +1,33 @@
+//! SECURE mirror: validate signed input before casting to unsigned.
+//!
+//! The positivity check is performed on the original `i128` value.  Only after
+//! the check passes is a safe `u128::try_from` conversion attempted, which
+//! panics on any remaining negative value rather than silently wrapping.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureVault;
+
+#[contractimpl]
+impl SecureVault {
+    /// ✅ Validates `amount > 0` on the signed type before converting.
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        // ✅ Guard on the signed value — negative inputs are caught here.
+        assert!(amount > 0, "amount must be positive");
+        // ✅ Checked conversion: panics if somehow still negative (belt-and-suspenders).
+        let unsigned = u128::try_from(amount).expect("amount out of range");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(user), &unsigned);
+    }
+
+    pub fn get_balance(env: Env, user: Address) -> u128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(user))
+            .unwrap_or(0)
+    }
+}


### PR DESCRIPTION
closes #239 
closes #240 
closes #241 
closes #242 

## Add 4 new vulnerable/secure fixture crates for scanner training

### Overview

Adds four focused Soroban smart contract crates under `vulnerable/`, each pairing a
vulnerable implementation (`src/lib.rs`) with a secure fix (`src/secure.rs`) and a full
test suite. All crates are registered in the workspace `Cargo.toml`.

---

### Changes

#### `vulnerable/empty_vault_share_inflation` — Critical

**Vulnerability:** The first depositor mints shares 1:1 from `amount` with no virtual
liquidity offset. An attacker seeds the vault with 1 unit, then donates a large amount
directly, inflating `total_assets` without minting shares. The next depositor's share
calculation floors to zero via integer division.

**Fix:** Apply a `VIRTUAL_OFFSET = 1_000` to both the numerator and denominator:

```rust
shares = amount * (total_shares + VIRTUAL_OFFSET) / (total_assets + VIRTUAL_OFFSET)
```

This prevents the first depositor from controlling the initial exchange rate.

**Tests:**
- Inflation attack causes victim to receive 0 shares (panics as expected)
- Attacker seed deposit of 1 unit succeeds, leaving unsafe state
- Secure vault preserves fair share allocation after donation

---

#### `vulnerable/vault_donation_accounting` — High

**Vulnerability:** `deposit()` reads a `LiveBalance` storage key as `total_assets`. This
key is also writable by `donate()`, which simulates an unsolicited token transfer. A
donation before a deposit inflates the denominator, reducing shares minted for the next
depositor.

**Fix:** Introduce a separate `ManagedAssets` key updated exclusively through `deposit()`.
The `donate()` function is accepted but intentionally ignored for share math.

**Tests:**
- Donation of 9_000 after Alice's 1_000 deposit causes Bob to receive 100 shares vs
  Alice's 1_000 for the same amount
- Donation-only state leaves `total_shares = 0` with inflated balance (unsafe boundary)
- Secure vault: equal deposits yield equal shares regardless of donations

---

#### `vulnerable/fee_precision_loss` — Medium

**Vulnerability:** Fee is computed as `amount * FEE_BPS / BPS_DENOM` (1% = `100 /
10_000`). For any `amount < 100`, integer division truncates the fee to 0. An attacker
splits a large transfer into chunks of 99 units, paying zero total fees.

**Fix:** Enforce a minimum fee of 1 when the rate is nonzero and the raw fee rounds to
zero:

```rust
let fee = if raw_fee == 0 && FEE_BPS > 0 { 1 } else { raw_fee };
```

**Tests:**
- Single transfer of 10_000 collects 100 in fees (correct baseline)
- 101 transfers of 99 units collect 0 fees (demonstrates bypass)
- Sub-threshold boundary: single transfer of 99 pays 0 fee (vulnerable)
- Secure: sub-threshold transfer collects minimum fee of 1
- Secure: 10 split transfers each collect 1 fee (total = 10)

---

#### `vulnerable/assumed_token_decimals` — High

**Vulnerability:** A multi-asset contract normalises all token amounts using a hardcoded
7-decimal scale (`amount * 10^7`). A 6-decimal token is over-valued by 10×; a 9-decimal
token is under-valued by 100×. This breaks collateral calculations, swap ratios, and
deposit caps.

**Fix:** Add a `register_token(symbol, decimals)` function that stores per-token
precision. Normalisation scales to a canonical 9-decimal base:

```rust
// token_decimals <= CANONICAL_DECIMALS (9)
normalised = amount * 10_i128.pow(CANONICAL_DECIMALS - token_decimals)
```

**Tests:**
- 1 raw unit of a 6-decimal and 9-decimal token both normalise to `10^7` (wrong, same
  value)
- Equal human-readable amounts in 6-dec and 9-dec produce different normalised values
  (incorrect accounting boundary)
- Secure: equal human amounts (`1_000_000` for 6-dec, `1_000_000_000` for 9-dec)
  normalise to the same canonical value

---

### Workspace

All 4 crates added to `[workspace.members]` in the root `Cargo.toml`.

---

### Checklist

- [x] Vulnerable path is reachable and scannable
- [x] Secure fix is in `src/secure.rs` within the same crate
- [x] Tests cover: vulnerable success, boundary condition, secure invariant
- [x] No `std`, no external dependencies beyond `soroban-sdk`
- [x] One commit per crate
