### PR TITLE
Feat/new vuln crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ members = [
     "vulnerable/expired_delegation",
     "vulnerable/uncapped_supply",
     "vulnerable/silent_admin_change",
+    "vulnerable/empty_vault_share_inflation",
+    "vulnerable/vault_donation_accounting",
+    "vulnerable/fee_precision_loss",
+    "vulnerable/assumed_token_decimals",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/assumed_token_decimals/Cargo.toml
+++ b/vulnerable/assumed_token_decimals/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "assumed-token-decimals"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating incorrect decimal assumption for multi-asset accounting"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/assumed_token_decimals/src/lib.rs
+++ b/vulnerable/assumed_token_decimals/src/lib.rs
@@ -1,0 +1,172 @@
+//! VULNERABLE: Assumed Token Decimals
+//!
+//! A multi-asset contract normalises all token amounts using a hardcoded 7-decimal
+//! scale. Tokens with 6 or 9 decimals are over- or under-valued, breaking
+//! collateral calculations, swap ratios, and deposit caps.
+//!
+//! VULNERABILITY: `normalised = amount * 10^7` applied to every token regardless
+//! of its actual decimal precision.
+//!
+//! SEVERITY: High
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+pub mod secure;
+
+/// Hardcoded assumed decimal precision — the bug.
+pub const ASSUMED_DECIMALS: u32 = 7;
+
+#[contracttype]
+pub enum DataKey {
+    /// Normalised balance per (token, user) pair.
+    Balance(Symbol, Address),
+    /// Total normalised value deposited per token.
+    TotalValue(Symbol),
+}
+
+pub(crate) fn normalised_balance(env: &Env, token: &Symbol, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(token.clone(), user.clone()))
+        .unwrap_or(0)
+}
+
+pub(crate) fn total_value(env: &Env, token: &Symbol) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TotalValue(token.clone()))
+        .unwrap_or(0)
+}
+
+/// Normalise `amount` using the hardcoded assumed decimal scale.
+pub fn normalise_vulnerable(amount: i128) -> i128 {
+    // ❌ BUG: always uses 7 decimals regardless of actual token precision.
+    amount * 10_i128.pow(ASSUMED_DECIMALS)
+}
+
+#[contract]
+pub struct VulnerableMultiAsset;
+
+#[contractimpl]
+impl VulnerableMultiAsset {
+    /// VULNERABLE: normalises `amount` with a hardcoded 7-decimal scale.
+    /// A 6-decimal token is over-valued by 10×; a 9-decimal token is under-valued by 100×.
+    pub fn deposit(env: Env, actor: Address, token: Symbol, amount: i128) {
+        actor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        // ❌ BUG: hardcoded decimal assumption.
+        let normalised = normalise_vulnerable(amount);
+
+        let prev = normalised_balance(&env, &token, &actor);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(token.clone(), actor), &(prev + normalised));
+
+        let tv = total_value(&env, &token);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalValue(token), &(tv + normalised));
+    }
+
+    pub fn balance(env: Env, token: Symbol, user: Address) -> i128 {
+        normalised_balance(&env, &token, &user)
+    }
+
+    pub fn total_value(env: Env, token: Symbol) -> i128 {
+        total_value(&env, &token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secure::SecureMultiAssetClient;
+    use soroban_sdk::{testutils::Address as _, symbol_short, Address, Env};
+
+    fn setup_vuln(env: &Env) -> VulnerableMultiAssetClient {
+        let id = env.register_contract(None, VulnerableMultiAsset);
+        VulnerableMultiAssetClient::new(env, &id)
+    }
+
+    fn setup_secure(env: &Env) -> SecureMultiAssetClient {
+        let id = env.register_contract(None, secure::SecureMultiAsset);
+        SecureMultiAssetClient::new(env, &id)
+    }
+
+    /// Demonstrates the vulnerability: 1 unit of a 6-decimal token and 1 unit
+    /// of a 9-decimal token are both normalised to the same value (10^7),
+    /// even though they represent very different real-world amounts.
+    #[test]
+    fn test_different_decimals_produce_same_normalised_value() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let alice = Address::generate(&env);
+        let token6 = symbol_short!("TK6"); // 6-decimal token
+        let token9 = symbol_short!("TK9"); // 9-decimal token
+
+        // Deposit 1 raw unit of each token
+        client.deposit(&alice, &token6, &1);
+        client.deposit(&alice, &token9, &1);
+
+        let val6 = client.balance(&token6, &alice);
+        let val9 = client.balance(&token9, &alice);
+
+        // ❌ Both normalise to 10^7 — incorrect for different decimal tokens
+        assert_eq!(val6, val9, "vulnerable: both tokens get same normalised value");
+        assert_eq!(val6, 10_i128.pow(7));
+    }
+
+    /// Boundary: equal human-readable amounts of 6-decimal and 9-decimal tokens
+    /// should have different raw amounts (1_000_000 vs 1_000_000_000) but the
+    /// vulnerable contract treats them identically after normalisation.
+    #[test]
+    fn test_equal_human_amounts_differ_in_raw_units() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let alice = Address::generate(&env);
+        let token6 = symbol_short!("TK6");
+        let token9 = symbol_short!("TK9");
+
+        // 1.0 in 6-decimal = 1_000_000 raw; 1.0 in 9-decimal = 1_000_000_000 raw
+        client.deposit(&alice, &token6, &1_000_000);
+        client.deposit(&alice, &token9, &1_000_000_000);
+
+        let val6 = client.balance(&token6, &alice);
+        let val9 = client.balance(&token9, &alice);
+
+        // ❌ Vulnerable: val9 is 1000× larger than val6 — incorrect accounting
+        assert_ne!(val6, val9, "vulnerable: equal human amounts produce unequal normalised values");
+    }
+
+    /// Secure: equal human-readable amounts normalise to the same canonical value.
+    #[test]
+    fn test_secure_equal_human_amounts_normalise_correctly() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_secure(&env);
+
+        let alice = Address::generate(&env);
+        let token6 = symbol_short!("TK6");
+        let token9 = symbol_short!("TK9");
+
+        // Register tokens with their actual decimals
+        client.register_token(&token6, &6u32);
+        client.register_token(&token9, &9u32);
+
+        // 1.0 in 6-decimal = 1_000_000 raw; 1.0 in 9-decimal = 1_000_000_000 raw
+        client.deposit(&alice, &token6, &1_000_000);
+        client.deposit(&alice, &token9, &1_000_000_000);
+
+        let val6 = client.balance(&token6, &alice);
+        let val9 = client.balance(&token9, &alice);
+
+        // ✅ Both represent 1.0 human unit → same canonical value
+        assert_eq!(val6, val9, "secure: equal human amounts produce equal normalised values");
+    }
+}

--- a/vulnerable/assumed_token_decimals/src/secure.rs
+++ b/vulnerable/assumed_token_decimals/src/secure.rs
@@ -1,0 +1,69 @@
+#![no_std]
+use super::{normalised_balance, total_value, DataKey};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+
+/// Canonical scale: all amounts normalised to 9 decimals internally.
+const CANONICAL_DECIMALS: u32 = 9;
+
+#[contracttype]
+pub enum SecureDataKey {
+    TokenDecimals(Symbol),
+}
+
+fn token_decimals(env: &Env, token: &Symbol) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&SecureDataKey::TokenDecimals(token.clone()))
+        .expect("token not registered")
+}
+
+/// Normalise `amount` from `token_decimals` to `CANONICAL_DECIMALS`.
+fn normalise(amount: i128, decimals: u32) -> i128 {
+    if decimals <= CANONICAL_DECIMALS {
+        amount * 10_i128.pow(CANONICAL_DECIMALS - decimals)
+    } else {
+        amount / 10_i128.pow(decimals - CANONICAL_DECIMALS)
+    }
+}
+
+#[contract]
+pub struct SecureMultiAsset;
+
+#[contractimpl]
+impl SecureMultiAsset {
+    /// Register a token with its actual decimal precision.
+    pub fn register_token(env: Env, token: Symbol, decimals: u32) {
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::TokenDecimals(token), &decimals);
+    }
+
+    /// SECURE: normalises using the per-token registered decimal count.
+    pub fn deposit(env: Env, actor: Address, token: Symbol, amount: i128) {
+        actor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        // ✅ Per-token decimal lookup — no hardcoded assumption.
+        let decimals = token_decimals(&env, &token);
+        let normalised = normalise(amount, decimals);
+        assert!(normalised > 0, "normalised amount is zero");
+
+        let prev = normalised_balance(&env, &token, &actor);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(token.clone(), actor), &(prev + normalised));
+
+        let tv = total_value(&env, &token);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalValue(token), &(tv + normalised));
+    }
+
+    pub fn balance(env: Env, token: Symbol, user: Address) -> i128 {
+        normalised_balance(&env, &token, &user)
+    }
+
+    pub fn total_value(env: Env, token: Symbol) -> i128 {
+        total_value(&env, &token)
+    }
+}

--- a/vulnerable/empty_vault_share_inflation/Cargo.toml
+++ b/vulnerable/empty_vault_share_inflation/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "empty-vault-share-inflation"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating vault share inflation via first-deposit manipulation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/empty_vault_share_inflation/src/lib.rs
+++ b/vulnerable/empty_vault_share_inflation/src/lib.rs
@@ -1,0 +1,175 @@
+//! VULNERABLE: Empty Vault Share Inflation
+//!
+//! The first depositor mints shares 1:1 from `amount` with no virtual liquidity
+//! or minimum initial deposit. An attacker seeds the vault with 1 unit, then
+//! donates a large amount directly, inflating the share price so that a victim
+//! depositing a normal amount receives 0 shares (integer division floors to 0).
+//!
+//! VULNERABILITY: `shares = amount * total_shares / total_assets` with no
+//! virtual offset — first depositor controls the initial exchange rate.
+//!
+//! SEVERITY: Critical
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    TotalShares,
+    TotalAssets,
+    Shares(Address),
+}
+
+fn total_shares(env: &Env) -> i128 {
+    env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(0)
+}
+
+fn total_assets(env: &Env) -> i128 {
+    env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(0)
+}
+
+fn shares_of(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Shares(user.clone()))
+        .unwrap_or(0)
+}
+
+#[contract]
+pub struct VulnerableVault;
+
+#[contractimpl]
+impl VulnerableVault {
+    /// VULNERABLE: first deposit sets share price with any amount, including 1.
+    /// Subsequent depositors receive shares = amount * total_shares / total_assets,
+    /// which floors to 0 when total_assets has been inflated by a donation.
+    ///
+    /// # Vulnerability
+    /// No virtual liquidity offset and no minimum first deposit.
+    pub fn deposit(env: Env, actor: Address, amount: i128) {
+        actor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let ts = total_shares(&env);
+        let ta = total_assets(&env);
+
+        // ❌ BUG: first depositor mints shares == amount, setting the price.
+        //    After a donation inflates ta, new shares floor to 0.
+        let new_shares = if ts == 0 {
+            amount
+        } else {
+            amount * ts / ta
+        };
+
+        assert!(new_shares > 0, "zero shares minted");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(ts + new_shares));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(ta + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(actor), &(shares_of(&env, &actor) + new_shares));
+    }
+
+    /// Donate assets directly — simulates an unsolicited token transfer that
+    /// inflates total_assets without minting shares.
+    pub fn donate(env: Env, amount: i128) {
+        assert!(amount > 0);
+        let ta = total_assets(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(ta + amount));
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        shares_of(&env, &user)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        total_shares(&env)
+    }
+
+    pub fn total_assets(env: Env) -> i128 {
+        total_assets(&env)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secure::SecureVaultClient;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup_vuln(env: &Env) -> VulnerableVaultClient {
+        let id = env.register_contract(None, VulnerableVault);
+        VulnerableVaultClient::new(env, &id)
+    }
+
+    fn setup_secure(env: &Env) -> SecureVaultClient {
+        let id = env.register_contract(None, secure::SecureVault);
+        SecureVaultClient::new(env, &id)
+    }
+
+    /// Demonstrates the vulnerable path: attacker seeds with 1, donates 1_000_000,
+    /// victim deposits 500_000 but receives 0 shares.
+    #[test]
+    #[should_panic(expected = "zero shares minted")]
+    fn test_share_inflation_victim_gets_zero_shares() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let attacker = Address::generate(&env);
+        let victim = Address::generate(&env);
+
+        // Attacker seeds vault with 1 unit → 1 share, price = 1:1
+        client.deposit(&attacker, &1);
+        assert_eq!(client.shares_of(&attacker), 1);
+
+        // Attacker donates 1_000_000 directly → total_assets = 1_000_001, total_shares = 1
+        client.donate(&1_000_000);
+
+        // Victim deposits 500_000 → shares = 500_000 * 1 / 1_000_001 = 0 → panic
+        client.deposit(&victim, &500_000);
+    }
+
+    /// Boundary: the attacker's own 1-unit seed deposit succeeds (unsafe state).
+    #[test]
+    fn test_attacker_seed_deposit_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let attacker = Address::generate(&env);
+        client.deposit(&attacker, &1);
+        assert_eq!(client.shares_of(&attacker), 1);
+        assert_eq!(client.total_assets(), 1);
+    }
+
+    /// Secure vault: victim receives fair shares after attacker's donation attempt.
+    #[test]
+    fn test_secure_victim_receives_fair_shares() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_secure(&env);
+
+        let attacker = Address::generate(&env);
+        let victim = Address::generate(&env);
+
+        // Attacker seeds with 1 unit — secure vault adds virtual offset
+        client.deposit(&attacker, &1);
+
+        // Attacker donates 1_000_000
+        client.donate(&1_000_000);
+
+        // Victim deposits 500_000 — virtual offset neutralises inflation
+        client.deposit(&victim, &500_000);
+        let victim_shares = client.shares_of(&victim);
+        assert!(victim_shares > 0, "victim must receive shares");
+    }
+}

--- a/vulnerable/empty_vault_share_inflation/src/secure.rs
+++ b/vulnerable/empty_vault_share_inflation/src/secure.rs
@@ -1,0 +1,61 @@
+#![no_std]
+use super::{shares_of, total_assets, total_shares, DataKey};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+/// Virtual offset applied to both assets and shares on first deposit.
+/// This prevents the first depositor from setting an arbitrary share price.
+const VIRTUAL_OFFSET: i128 = 1_000;
+
+#[contract]
+pub struct SecureVault;
+
+#[contractimpl]
+impl SecureVault {
+    /// SECURE: uses virtual assets + virtual shares so the first depositor
+    /// cannot manipulate the initial exchange rate.
+    ///
+    /// shares_minted = amount * (total_shares + VIRTUAL_OFFSET)
+    ///                        / (total_assets + VIRTUAL_OFFSET)
+    pub fn deposit(env: Env, actor: Address, amount: i128) {
+        actor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let ts = total_shares(&env);
+        let ta = total_assets(&env);
+
+        // ✅ Virtual offset prevents share-price manipulation on empty vault.
+        let new_shares = amount * (ts + VIRTUAL_OFFSET) / (ta + VIRTUAL_OFFSET);
+        assert!(new_shares > 0, "zero shares minted");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(ts + new_shares));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(ta + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(actor.clone()), &(shares_of(&env, &actor) + new_shares));
+    }
+
+    /// Donate assets — simulates unsolicited transfer.
+    pub fn donate(env: Env, amount: i128) {
+        assert!(amount > 0);
+        let ta = total_assets(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(ta + amount));
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        shares_of(&env, &user)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        total_shares(&env)
+    }
+
+    pub fn total_assets(env: Env) -> i128 {
+        total_assets(&env)
+    }
+}

--- a/vulnerable/fee_precision_loss/Cargo.toml
+++ b/vulnerable/fee_precision_loss/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fee-precision-loss"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating fee bypass via integer division truncation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/fee_precision_loss/src/lib.rs
+++ b/vulnerable/fee_precision_loss/src/lib.rs
@@ -1,0 +1,194 @@
+//! VULNERABLE: Fee Precision Loss via Integer Division Truncation
+//!
+//! A 1% fee (rate = 100 bps out of 10_000) floors to 0 for any transfer
+//! amount < 100. An attacker splits a large transfer into many dust chunks,
+//! each paying zero fee, bypassing the protocol fee entirely.
+//!
+//! VULNERABILITY: `fee = amount * FEE_BPS / 10_000` truncates to 0 when
+//! `amount < 10_000 / FEE_BPS`. No minimum fee is enforced.
+//!
+//! SEVERITY: Medium
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+/// 1% fee expressed in basis points.
+pub const FEE_BPS: i128 = 100;
+pub const BPS_DENOM: i128 = 10_000;
+
+#[contracttype]
+pub enum DataKey {
+    Balance(Address),
+    FeesCollected,
+}
+
+pub(crate) fn balance_of(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Balance(user.clone()))
+        .unwrap_or(0)
+}
+
+pub(crate) fn fees_collected(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::FeesCollected)
+        .unwrap_or(0)
+}
+
+#[contract]
+pub struct VulnerableFeeContract;
+
+#[contractimpl]
+impl VulnerableFeeContract {
+    pub fn mint(env: Env, user: Address, amount: i128) {
+        assert!(amount > 0);
+        let bal = balance_of(&env, &user);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(user), &(bal + amount));
+    }
+
+    /// VULNERABLE: fee floors to 0 for small amounts.
+    ///
+    /// # Vulnerability
+    /// `fee = amount * FEE_BPS / BPS_DENOM` — for amount < 100 this is 0.
+    /// Splitting a large transfer into chunks of 99 pays zero total fees.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        // ❌ BUG: integer division truncates fee to 0 for small amounts.
+        let fee = amount * FEE_BPS / BPS_DENOM;
+
+        let from_bal = balance_of(&env, &from);
+        assert!(from_bal >= amount, "insufficient balance");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(from), &(from_bal - amount));
+
+        let to_bal = balance_of(&env, &to);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(to), &(to_bal + amount - fee));
+
+        let collected = fees_collected(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeesCollected, &(collected + fee));
+    }
+
+    pub fn balance(env: Env, user: Address) -> i128 {
+        balance_of(&env, &user)
+    }
+
+    pub fn fees_collected(env: Env) -> i128 {
+        fees_collected(&env)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secure::SecureFeeContractClient;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup_vuln(env: &Env) -> VulnerableFeeContractClient {
+        let id = env.register_contract(None, VulnerableFeeContract);
+        VulnerableFeeContractClient::new(env, &id)
+    }
+
+    fn setup_secure(env: &Env) -> SecureFeeContractClient {
+        let id = env.register_contract(None, secure::SecureFeeContract);
+        SecureFeeContractClient::new(env, &id)
+    }
+
+    /// One large transfer of 10_000 collects 100 in fees (correct).
+    #[test]
+    fn test_single_large_transfer_collects_fee() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint(&alice, &10_000);
+
+        client.transfer(&alice, &bob, &10_000);
+        assert_eq!(client.fees_collected(), 100);
+    }
+
+    /// Demonstrates the vulnerability: 101 transfers of 99 units each
+    /// (total = 9_999) collect 0 fees — attacker bypasses the 1% fee.
+    #[test]
+    fn test_split_transfers_bypass_fee() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        // Mint enough for 101 chunks of 99
+        client.mint(&alice, &9_999);
+
+        for _ in 0..101 {
+            client.mint(&alice, &99); // top up per iteration for simplicity
+            client.transfer(&alice, &bob, &99);
+        }
+
+        // ❌ Zero fees collected despite 101 non-zero transfers
+        assert_eq!(client.fees_collected(), 0);
+    }
+
+    /// Boundary: a single transfer of 99 (below fee threshold) pays 0 fee.
+    #[test]
+    fn test_below_threshold_pays_zero_fee() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint(&alice, &99);
+
+        client.transfer(&alice, &bob, &99);
+        assert_eq!(client.fees_collected(), 0);
+    }
+
+    /// Secure: transfer of 99 still collects minimum fee of 1.
+    #[test]
+    fn test_secure_minimum_fee_enforced() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_secure(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        client.mint(&alice, &99);
+
+        client.transfer(&alice, &bob, &99);
+        // ✅ Minimum fee of 1 collected even for sub-threshold amounts
+        assert_eq!(client.fees_collected(), 1);
+    }
+
+    /// Secure: split transfers still collect at least 1 fee per transfer.
+    #[test]
+    fn test_secure_split_transfers_collect_fees() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_secure(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        for _ in 0..10 {
+            client.mint(&alice, &99);
+            client.transfer(&alice, &bob, &99);
+        }
+
+        assert_eq!(client.fees_collected(), 10);
+    }
+}

--- a/vulnerable/fee_precision_loss/src/secure.rs
+++ b/vulnerable/fee_precision_loss/src/secure.rs
@@ -1,0 +1,52 @@
+#![no_std]
+use super::{balance_of, fees_collected, BPS_DENOM, FEE_BPS, DataKey};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureFeeContract;
+
+#[contractimpl]
+impl SecureFeeContract {
+    pub fn mint(env: Env, user: Address, amount: i128) {
+        assert!(amount > 0);
+        let bal = balance_of(&env, &user);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(user), &(bal + amount));
+    }
+
+    /// SECURE: enforces a minimum fee of 1 when a nonzero rate applies.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let raw_fee = amount * FEE_BPS / BPS_DENOM;
+        // ✅ Minimum fee of 1 prevents dust-split fee bypass.
+        let fee = if raw_fee == 0 && FEE_BPS > 0 { 1 } else { raw_fee };
+
+        let from_bal = balance_of(&env, &from);
+        assert!(from_bal >= amount, "insufficient balance");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(from), &(from_bal - amount));
+
+        let to_bal = balance_of(&env, &to);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(to), &(to_bal + amount - fee));
+
+        let collected = fees_collected(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::FeesCollected, &(collected + fee));
+    }
+
+    pub fn balance(env: Env, user: Address) -> i128 {
+        balance_of(&env, &user)
+    }
+
+    pub fn fees_collected(env: Env) -> i128 {
+        fees_collected(&env)
+    }
+}

--- a/vulnerable/vault_donation_accounting/Cargo.toml
+++ b/vulnerable/vault_donation_accounting/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vault-donation-accounting"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating donation-based share price manipulation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/vault_donation_accounting/src/lib.rs
+++ b/vulnerable/vault_donation_accounting/src/lib.rs
@@ -1,0 +1,172 @@
+//! VULNERABLE: Vault Donation Accounting
+//!
+//! The vault computes `total_assets` from a live balance field that any caller
+//! can inflate via `donate()`. Because share minting uses this live value,
+//! an unsolicited donation shifts the share price before the next depositor,
+//! causing them to receive fewer shares than they should.
+//!
+//! VULNERABILITY: share math reads live token balance instead of a managed
+//! internal counter that only changes through controlled deposit/withdraw paths.
+//!
+//! SEVERITY: High
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    /// Live balance — writable by donate(), not just deposit().
+    LiveBalance,
+    TotalShares,
+    Shares(Address),
+}
+
+pub(crate) fn live_balance(env: &Env) -> i128 {
+    env.storage().persistent().get(&DataKey::LiveBalance).unwrap_or(0)
+}
+
+pub(crate) fn total_shares(env: &Env) -> i128 {
+    env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(0)
+}
+
+pub(crate) fn shares_of(env: &Env, user: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Shares(user.clone()))
+        .unwrap_or(0)
+}
+
+#[contract]
+pub struct VulnerableVault;
+
+#[contractimpl]
+impl VulnerableVault {
+    /// VULNERABLE: uses `live_balance` (inflatable by donate) as total_assets.
+    ///
+    /// # Vulnerability
+    /// A donation before this call inflates the denominator, reducing shares minted.
+    pub fn deposit(env: Env, actor: Address, amount: i128) {
+        actor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let ts = total_shares(&env);
+        // ❌ BUG: reads live balance — donations shift this value externally.
+        let ta = live_balance(&env);
+
+        let new_shares = if ts == 0 { amount } else { amount * ts / ta };
+        assert!(new_shares > 0, "zero shares minted");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::LiveBalance, &(ta + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(ts + new_shares));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(actor), &(shares_of(&env, &actor) + new_shares));
+    }
+
+    /// Simulates an unsolicited token transfer — inflates live balance without
+    /// minting shares, distorting the share price for the next depositor.
+    pub fn donate(env: Env, amount: i128) {
+        assert!(amount > 0);
+        let bal = live_balance(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LiveBalance, &(bal + amount));
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        shares_of(&env, &user)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        total_shares(&env)
+    }
+
+    pub fn total_assets(env: Env) -> i128 {
+        live_balance(&env)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secure::SecureVaultClient;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup_vuln(env: &Env) -> VulnerableVaultClient {
+        let id = env.register_contract(None, VulnerableVault);
+        VulnerableVaultClient::new(env, &id)
+    }
+
+    fn setup_secure(env: &Env) -> SecureVaultClient {
+        let id = env.register_contract(None, secure::SecureVault);
+        SecureVaultClient::new(env, &id)
+    }
+
+    /// Demonstrates the vulnerability: donation shifts share accounting.
+    /// Alice deposits 1_000 → 1_000 shares. Attacker donates 9_000.
+    /// Bob deposits 1_000 → should get ~1_000 shares but gets 100.
+    #[test]
+    fn test_donation_distorts_share_price() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.deposit(&alice, &1_000);
+        assert_eq!(client.shares_of(&alice), 1_000);
+
+        // Attacker donates 9_000 — live balance becomes 10_000, shares still 1_000
+        client.donate(&9_000);
+
+        // Bob deposits same 1_000 → shares = 1_000 * 1_000 / 10_000 = 100
+        client.deposit(&bob, &1_000);
+        let bob_shares = client.shares_of(&bob);
+
+        // ❌ Bob receives far fewer shares than Alice for the same deposit
+        assert!(bob_shares < client.shares_of(&alice), "donation distorted share price");
+        assert_eq!(bob_shares, 100);
+    }
+
+    /// Boundary: donation alone (no prior deposit) leaves unsafe state.
+    #[test]
+    fn test_donation_before_any_deposit_inflates_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_vuln(&env);
+
+        client.donate(&1_000_000);
+        assert_eq!(client.total_assets(), 1_000_000);
+        assert_eq!(client.total_shares(), 0);
+    }
+
+    /// Secure vault: donation does NOT affect internal managed assets counter.
+    #[test]
+    fn test_secure_donation_does_not_shift_share_price() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let client = setup_secure(&env);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.deposit(&alice, &1_000);
+        let alice_shares = client.shares_of(&alice);
+
+        // Donate — secure vault ignores this for share math
+        client.donate(&9_000);
+
+        // Bob deposits same amount — should receive same shares as Alice
+        client.deposit(&bob, &1_000);
+        let bob_shares = client.shares_of(&bob);
+
+        assert_eq!(alice_shares, bob_shares, "secure vault preserves share price");
+    }
+}

--- a/vulnerable/vault_donation_accounting/src/secure.rs
+++ b/vulnerable/vault_donation_accounting/src/secure.rs
@@ -1,0 +1,61 @@
+#![no_std]
+use super::{shares_of, total_shares, DataKey};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+/// Internal managed assets — only updated through deposit/withdraw, never by donate.
+const MANAGED_ASSETS_KEY: &str = "ManagedAssets";
+
+fn managed_assets(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&soroban_sdk::Symbol::new(env, MANAGED_ASSETS_KEY))
+        .unwrap_or(0)
+}
+
+#[contract]
+pub struct SecureVault;
+
+#[contractimpl]
+impl SecureVault {
+    /// SECURE: uses an internal managed-assets counter instead of live balance.
+    /// Donations do not affect share math.
+    pub fn deposit(env: Env, actor: Address, amount: i128) {
+        actor.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let ts = total_shares(&env);
+        // ✅ Reads managed counter — immune to external donations.
+        let ta = managed_assets(&env);
+
+        let new_shares = if ts == 0 { amount } else { amount * ts / ta };
+        assert!(new_shares > 0, "zero shares minted");
+
+        let key = soroban_sdk::Symbol::new(&env, MANAGED_ASSETS_KEY);
+        env.storage().persistent().set(&key, &(ta + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(ts + new_shares));
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(actor.clone()), &(shares_of(&env, &actor) + new_shares));
+    }
+
+    /// Donate is accepted but does NOT update managed assets — share math is unaffected.
+    pub fn donate(env: Env, amount: i128) {
+        assert!(amount > 0);
+        // ✅ Intentionally ignored for share accounting purposes.
+        let _ = (env, amount);
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        shares_of(&env, &user)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        total_shares(&env)
+    }
+
+    pub fn managed_assets(env: Env) -> i128 {
+        managed_assets(&env)
+    }
+}


### PR DESCRIPTION
closes #235 
closes #236 
closes #237 
closes #238 

## Add 4 new vulnerable/secure fixture crates for scanner training

### Overview

Adds four focused Soroban smart contract crates under `vulnerable/`, each pairing a
vulnerable implementation (`src/lib.rs`) with a secure fix (`src/secure.rs`) and a full
test suite. All crates are registered in the workspace `Cargo.toml`.

---

### Changes

#### `vulnerable/empty_vault_share_inflation` — Critical

**Vulnerability:** The first depositor mints shares 1:1 from `amount` with no virtual
liquidity offset. An attacker seeds the vault with 1 unit, then donates a large amount
directly, inflating `total_assets` without minting shares. The next depositor's share
calculation floors to zero via integer division.

**Fix:** Apply a `VIRTUAL_OFFSET = 1_000` to both the numerator and denominator:

```rust
shares = amount * (total_shares + VIRTUAL_OFFSET) / (total_assets + VIRTUAL_OFFSET)
```

This prevents the first depositor from controlling the initial exchange rate.

**Tests:**
- Inflation attack causes victim to receive 0 shares (panics as expected)
- Attacker seed deposit of 1 unit succeeds, leaving unsafe state
- Secure vault preserves fair share allocation after donation

---

#### `vulnerable/vault_donation_accounting` — High

**Vulnerability:** `deposit()` reads a `LiveBalance` storage key as `total_assets`. This
key is also writable by `donate()`, which simulates an unsolicited token transfer. A
donation before a deposit inflates the denominator, reducing shares minted for the next
depositor.

**Fix:** Introduce a separate `ManagedAssets` key updated exclusively through `deposit()`.
The `donate()` function is accepted but intentionally ignored for share math.

**Tests:**
- Donation of 9_000 after Alice's 1_000 deposit causes Bob to receive 100 shares vs
  Alice's 1_000 for the same amount
- Donation-only state leaves `total_shares = 0` with inflated balance (unsafe boundary)
- Secure vault: equal deposits yield equal shares regardless of donations

---

#### `vulnerable/fee_precision_loss` — Medium

**Vulnerability:** Fee is computed as `amount * FEE_BPS / BPS_DENOM` (1% = `100 /
10_000`). For any `amount < 100`, integer division truncates the fee to 0. An attacker
splits a large transfer into chunks of 99 units, paying zero total fees.

**Fix:** Enforce a minimum fee of 1 when the rate is nonzero and the raw fee rounds to
zero:

```rust
let fee = if raw_fee == 0 && FEE_BPS > 0 { 1 } else { raw_fee };
```

**Tests:**
- Single transfer of 10_000 collects 100 in fees (correct baseline)
- 101 transfers of 99 units collect 0 fees (demonstrates bypass)
- Sub-threshold boundary: single transfer of 99 pays 0 fee (vulnerable)
- Secure: sub-threshold transfer collects minimum fee of 1
- Secure: 10 split transfers each collect 1 fee (total = 10)

---

#### `vulnerable/assumed_token_decimals` — High

**Vulnerability:** A multi-asset contract normalises all token amounts using a hardcoded
7-decimal scale (`amount * 10^7`). A 6-decimal token is over-valued by 10×; a 9-decimal
token is under-valued by 100×. This breaks collateral calculations, swap ratios, and
deposit caps.

**Fix:** Add a `register_token(symbol, decimals)` function that stores per-token
precision. Normalisation scales to a canonical 9-decimal base:

```rust
// token_decimals <= CANONICAL_DECIMALS (9)
normalised = amount * 10_i128.pow(CANONICAL_DECIMALS - token_decimals)
```

**Tests:**
- 1 raw unit of a 6-decimal and 9-decimal token both normalise to `10^7` (wrong, same
  value)
- Equal human-readable amounts in 6-dec and 9-dec produce different normalised values
  (incorrect accounting boundary)
- Secure: equal human amounts (`1_000_000` for 6-dec, `1_000_000_000` for 9-dec)
  normalise to the same canonical value

---

### Workspace

All 4 crates added to `[workspace.members]` in the root `Cargo.toml`.

---

### Checklist

- [x] Vulnerable path is reachable and scannable
- [x] Secure fix is in `src/secure.rs` within the same crate
- [x] Tests cover: vulnerable success, boundary condition, secure invariant
- [x] No `std`, no external dependencies beyond `soroban-sdk`
- [x] One commit per crate
