### PR TITLE
Feat/new vulnerability crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ members = [
     "vulnerable/expired_delegation",
     "vulnerable/uncapped_supply",
     "vulnerable/silent_admin_change",
+    "vulnerable/unchecked_fee_collector",
+    "vulnerable/untrusted_oracle_setter",
+    "vulnerable/zero_share_rounding",
+    "vulnerable/withdraw_rounding_leak",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/unchecked_fee_collector/Cargo.toml
+++ b/vulnerable/unchecked_fee_collector/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "unchecked-fee-collector"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract: fee collector address accepted without validation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/unchecked_fee_collector/src/lib.rs
+++ b/vulnerable/unchecked_fee_collector/src/lib.rs
@@ -1,0 +1,186 @@
+//! VULNERABLE: Unchecked Fee Collector
+//!
+//! A fee contract where `set_collector` stores any address as the fee
+//! collector without requiring admin authorisation or validating that the
+//! address is on an approved list.  Fees can be silently redirected to an
+//! attacker-controlled address or to an address incapable of receiving tokens.
+//!
+//! VULNERABILITY: `set_collector` trusts the caller-supplied address with no
+//! auth check and no allowlist validation.
+//!
+//! SECURE MIRROR: `secure::SecureFeeCollector` requires admin auth and
+//! rejects collectors that are not on the approved list.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Vec};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Collector,
+    Fees,
+    Approved,
+}
+
+#[contract]
+pub struct UncheckedFeeCollector;
+
+#[contractimpl]
+impl UncheckedFeeCollector {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Fees, &0i128);
+    }
+
+    /// VULNERABLE: any caller can redirect fees to any address — no auth, no allowlist.
+    pub fn set_collector(env: Env, collector: Address) {
+        // ❌ Missing: admin.require_auth()
+        // ❌ Missing: assert collector is on approved list
+        env.storage().persistent().set(&DataKey::Collector, &collector);
+    }
+
+    /// Accumulate a flat fee from a notional operation.
+    pub fn collect_fee(env: Env, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        let fee = amount / 100; // 1 %
+        let current: i128 = env.storage().persistent().get(&DataKey::Fees).unwrap_or(0);
+        env.storage().persistent().set(&DataKey::Fees, &(current + fee));
+        env.events().publish((symbol_short!("fee"),), fee);
+    }
+
+    /// Transfer accumulated fees to the stored collector.
+    pub fn withdraw(env: Env) {
+        let collector: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collector)
+            .expect("collector not set");
+        let fees: i128 = env.storage().persistent().get(&DataKey::Fees).unwrap_or(0);
+        env.storage().persistent().set(&DataKey::Fees, &0i128);
+        env.events().publish((symbol_short!("withdraw"),), (collector, fees));
+    }
+
+    pub fn get_fees(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::Fees).unwrap_or(0)
+    }
+
+    pub fn get_collector(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Collector)
+            .expect("collector not set")
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    /// Add an address to the approved-collector list (admin only, used by secure path).
+    pub fn add_approved(env: Env, collector: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        let mut list: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Approved)
+            .unwrap_or(Vec::new(&env));
+        list.push_back(collector);
+        env.storage().persistent().set(&DataKey::Approved, &list);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup(env: &Env) -> (Address, UncheckedFeeCollectorClient) {
+        let id = env.register_contract(None, UncheckedFeeCollector);
+        let client = UncheckedFeeCollectorClient::new(env, &id);
+        let admin = Address::generate(env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        (admin, client)
+    }
+
+    /// DEMONSTRATES VULNERABILITY: attacker redirects collector without auth.
+    #[test]
+    fn test_attacker_redirects_collector() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env);
+        env.mock_all_auths();
+
+        let attacker = Address::generate(&env);
+        // No auth required — attacker sets themselves as collector.
+        client.set_collector(&attacker);
+        assert_eq!(client.get_collector(), attacker);
+
+        client.collect_fee(&1000);
+        assert_eq!(client.get_fees(), 10);
+
+        // Fees now drain to the attacker.
+        client.withdraw();
+        assert_eq!(client.get_fees(), 0);
+    }
+
+    /// Boundary: collector can be set to any arbitrary address (zero-value risk).
+    #[test]
+    fn test_any_address_accepted_as_collector() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env);
+        env.mock_all_auths();
+
+        let random = Address::generate(&env);
+        client.set_collector(&random);
+        assert_eq!(client.get_collector(), random);
+    }
+
+    /// SECURE: only admin can set collector, and only from the approved list.
+    #[test]
+    fn test_secure_rejects_unapproved_collector() {
+        use crate::secure::SecureFeeCollectorClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureFeeCollector);
+        let client = SecureFeeCollectorClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+
+        let attacker = Address::generate(&env);
+        // attacker is not on the approved list — must panic.
+        let result = std::panic::catch_unwind(|| client.set_collector(&attacker));
+        assert!(result.is_err(), "unapproved collector must be rejected");
+    }
+
+    /// SECURE: approved collector is accepted.
+    #[test]
+    fn test_secure_accepts_approved_collector() {
+        use crate::secure::SecureFeeCollectorClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureFeeCollector);
+        let client = SecureFeeCollectorClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+
+        let approved = Address::generate(&env);
+        client.add_approved(&approved);
+        client.set_collector(&approved);
+        assert_eq!(client.get_collector(), approved);
+    }
+}

--- a/vulnerable/unchecked_fee_collector/src/secure.rs
+++ b/vulnerable/unchecked_fee_collector/src/secure.rs
@@ -1,0 +1,71 @@
+//! SECURE mirror: require admin auth and allowlist validation before storing a fee collector.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+#[contract]
+pub struct SecureFeeCollector;
+
+#[contractimpl]
+impl SecureFeeCollector {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Fees, &0i128);
+    }
+
+    /// ✅ Only admin can change the collector, and only to an approved address.
+    pub fn set_collector(env: Env, collector: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let list: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Approved)
+            .unwrap_or(Vec::new(&env));
+        assert!(list.contains(&collector), "collector not approved");
+
+        env.storage().persistent().set(&DataKey::Collector, &collector);
+    }
+
+    pub fn add_approved(env: Env, collector: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        let mut list: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Approved)
+            .unwrap_or(Vec::new(&env));
+        list.push_back(collector);
+        env.storage().persistent().set(&DataKey::Approved, &list);
+    }
+
+    pub fn collect_fee(env: Env, amount: i128) {
+        assert!(amount > 0, "amount must be positive");
+        let fee = amount / 100;
+        let current: i128 = env.storage().persistent().get(&DataKey::Fees).unwrap_or(0);
+        env.storage().persistent().set(&DataKey::Fees, &(current + fee));
+    }
+
+    pub fn get_fees(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::Fees).unwrap_or(0)
+    }
+
+    pub fn get_collector(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Collector)
+            .expect("collector not set")
+    }
+}

--- a/vulnerable/untrusted_oracle_setter/Cargo.toml
+++ b/vulnerable/untrusted_oracle_setter/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "untrusted-oracle-setter"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract: oracle address stored without allowlist validation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/untrusted_oracle_setter/src/lib.rs
+++ b/vulnerable/untrusted_oracle_setter/src/lib.rs
@@ -1,0 +1,183 @@
+//! VULNERABLE: Untrusted Oracle Setter
+//!
+//! A governance function lets anyone store an arbitrary oracle address.
+//! No allowlist or interface check is performed.  A malicious oracle can
+//! return inflated prices, enabling over-collateralised borrows or
+//! sandwich attacks against any contract that reads the stored oracle.
+//!
+//! VULNERABILITY: `set_oracle` stores the caller-supplied address without
+//! verifying it against an approved registry.
+//!
+//! SEVERITY: Critical
+//!
+//! SECURE MIRROR: `secure::SecureOracleSetter` requires admin auth and
+//! validates the oracle address against an on-chain allowlist.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Oracle,
+    Allowlist,
+}
+
+#[contract]
+pub struct UntrustedOracleSetter;
+
+#[contractimpl]
+impl UntrustedOracleSetter {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// VULNERABLE: stores any oracle address with no auth and no allowlist check.
+    pub fn set_oracle(env: Env, oracle: Address) {
+        // ❌ Missing: admin.require_auth()
+        // ❌ Missing: assert oracle is on allowlist
+        env.storage().persistent().set(&DataKey::Oracle, &oracle);
+    }
+
+    /// Read the price from whatever oracle address was stored.
+    /// In a real contract this would cross-call the oracle; here we simulate
+    /// by reading a price the oracle "reported" into shared storage.
+    pub fn get_price(env: Env) -> i128 {
+        let oracle: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Oracle)
+            .expect("oracle not set");
+        // Simulate reading from the oracle: in tests the oracle address is used
+        // as a key to look up a price injected by the test harness.
+        env.storage()
+            .persistent()
+            .get(&oracle)
+            .unwrap_or(0)
+    }
+
+    /// Test helper: inject a price that `get_price` will return for `oracle`.
+    pub fn mock_oracle_price(env: Env, oracle: Address, price: i128) {
+        env.storage().persistent().set(&oracle, &price);
+    }
+
+    pub fn get_oracle(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Oracle)
+            .expect("oracle not set")
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    /// Add an address to the oracle allowlist (admin only, used by secure path).
+    pub fn add_to_allowlist(env: Env, oracle: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        let mut list: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Allowlist)
+            .unwrap_or(Vec::new(&env));
+        list.push_back(oracle);
+        env.storage().persistent().set(&DataKey::Allowlist, &list);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup(env: &Env) -> (Address, UntrustedOracleSetterClient) {
+        let id = env.register_contract(None, UntrustedOracleSetter);
+        let client = UntrustedOracleSetterClient::new(env, &id);
+        let admin = Address::generate(env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        (admin, client)
+    }
+
+    /// DEMONSTRATES VULNERABILITY: malicious oracle returns inflated price.
+    #[test]
+    fn test_malicious_oracle_inflates_price() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env);
+        env.mock_all_auths();
+
+        let malicious_oracle = Address::generate(&env);
+        // Inject an inflated price for the malicious oracle.
+        client.mock_oracle_price(&malicious_oracle, &999_999_999);
+
+        // No auth required — attacker sets their oracle.
+        client.set_oracle(&malicious_oracle);
+        assert_eq!(client.get_oracle(), malicious_oracle);
+
+        // Contract now reads the manipulated price.
+        let price = client.get_price();
+        assert_eq!(price, 999_999_999, "malicious oracle price accepted");
+    }
+
+    /// Boundary: any address is accepted, including one with no price data.
+    #[test]
+    fn test_arbitrary_address_accepted() {
+        let env = Env::default();
+        let (_admin, client) = setup(&env);
+        env.mock_all_auths();
+
+        let random = Address::generate(&env);
+        client.set_oracle(&random);
+        // No price injected — returns 0 (silent failure in a real contract).
+        assert_eq!(client.get_price(), 0);
+    }
+
+    /// SECURE: non-allowlisted oracle is rejected.
+    #[test]
+    fn test_secure_rejects_non_allowlisted_oracle() {
+        use crate::secure::SecureOracleSetterClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureOracleSetter);
+        let client = SecureOracleSetterClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+
+        let malicious = Address::generate(&env);
+        let result = std::panic::catch_unwind(|| client.set_oracle(&malicious));
+        assert!(result.is_err(), "non-allowlisted oracle must be rejected");
+    }
+
+    /// SECURE: allowlisted oracle is accepted.
+    #[test]
+    fn test_secure_accepts_allowlisted_oracle() {
+        use crate::secure::SecureOracleSetterClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureOracleSetter);
+        let client = SecureOracleSetterClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+
+        let trusted = Address::generate(&env);
+        client.add_to_allowlist(&trusted);
+        client.set_oracle(&trusted);
+        assert_eq!(client.get_oracle(), trusted);
+    }
+}

--- a/vulnerable/untrusted_oracle_setter/src/secure.rs
+++ b/vulnerable/untrusted_oracle_setter/src/secure.rs
@@ -1,0 +1,59 @@
+//! SECURE mirror: require admin auth and allowlist validation before storing an oracle.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+#[contract]
+pub struct SecureOracleSetter;
+
+#[contractimpl]
+impl SecureOracleSetter {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// ✅ Admin auth required; oracle must be on the allowlist.
+    pub fn set_oracle(env: Env, oracle: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+
+        let list: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Allowlist)
+            .unwrap_or(Vec::new(&env));
+        assert!(list.contains(&oracle), "oracle not on allowlist");
+
+        env.storage().persistent().set(&DataKey::Oracle, &oracle);
+    }
+
+    pub fn add_to_allowlist(env: Env, oracle: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        let mut list: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Allowlist)
+            .unwrap_or(Vec::new(&env));
+        list.push_back(oracle);
+        env.storage().persistent().set(&DataKey::Allowlist, &list);
+    }
+
+    pub fn get_oracle(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Oracle)
+            .expect("oracle not set")
+    }
+}

--- a/vulnerable/withdraw_rounding_leak/Cargo.toml
+++ b/vulnerable/withdraw_rounding_leak/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "withdraw-rounding-leak"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban vault: withdrawal rounds shares burned down, leaking value"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/withdraw_rounding_leak/src/lib.rs
+++ b/vulnerable/withdraw_rounding_leak/src/lib.rs
@@ -1,0 +1,192 @@
+//! VULNERABLE: Withdrawal Rounding Leak
+//!
+//! A vault computes `shares_to_burn = assets_requested * total_shares / total_assets`.
+//! Integer division floors the result in favour of the withdrawer.  Repeated
+//! small withdrawals extract assets while burning fewer shares than the
+//! proportional amount, slowly draining value from other depositors.
+//!
+//! VULNERABILITY: `withdraw` does not round `shares_to_burn` up, and does not
+//! reject withdrawals whose computed burn is zero.
+//!
+//! SEVERITY: High
+//!
+//! SECURE MIRROR: `secure::SecureVault` rounds `shares_to_burn` up (ceiling
+//! division) and panics when the result is zero.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    TotalAssets,
+    TotalShares,
+    Shares(Address),
+}
+
+#[contract]
+pub struct WithdrawRoundingVault;
+
+#[contractimpl]
+impl WithdrawRoundingVault {
+    pub fn initialize(env: Env, seed_assets: i128, seed_shares: i128) {
+        assert!(seed_assets > 0 && seed_shares > 0, "seed must be positive");
+        if env.storage().persistent().has(&DataKey::TotalAssets) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::TotalAssets, &seed_assets);
+        env.storage().persistent().set(&DataKey::TotalShares, &seed_shares);
+    }
+
+    /// Seed a user's share balance directly (test helper).
+    pub fn seed_shares(env: Env, user: Address, shares: i128) {
+        env.storage().persistent().set(&DataKey::Shares(user), &shares);
+    }
+
+    /// VULNERABLE: `shares_to_burn` floors in favour of the withdrawer.
+    pub fn withdraw(env: Env, user: Address, assets: i128) {
+        user.require_auth();
+        assert!(assets > 0, "assets must be positive");
+
+        let total_assets: i128 = env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(1);
+        let total_shares: i128 = env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(1);
+
+        // ❌ Floor division — withdrawer pays fewer shares than they should.
+        let shares_to_burn = assets * total_shares / total_assets;
+
+        // ❌ Missing: assert!(shares_to_burn > 0, "withdrawal burns zero shares");
+
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Shares(user.clone()))
+            .unwrap_or(0);
+        assert!(current >= shares_to_burn, "insufficient shares");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(user), &(current - shares_to_burn));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(total_assets - assets));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(total_shares - shares_to_burn));
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Shares(user))
+            .unwrap_or(0)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(0)
+    }
+
+    pub fn total_assets(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup(env: &Env) -> (WithdrawRoundingVaultClient, Address) {
+        let id = env.register_contract(None, WithdrawRoundingVault);
+        let client = WithdrawRoundingVaultClient::new(env, &id);
+        env.mock_all_auths();
+        // 1000 assets, 1000 shares → 1:1 share price.
+        client.initialize(&1000, &1000);
+        let user = Address::generate(env);
+        // Give user 500 shares.
+        client.seed_shares(&user, &500);
+        (client, user)
+    }
+
+    /// DEMONSTRATES VULNERABILITY: repeated 1-asset withdrawals burn zero shares.
+    #[test]
+    fn test_repeated_withdrawals_drain_assets_without_burning_shares() {
+        let env = Env::default();
+        let (client, user) = setup(&env);
+        env.mock_all_auths();
+
+        // With 1000 assets and 1000 shares, withdrawing 1 asset should burn 1 share.
+        // But if we manipulate the ratio first (inflate assets without shares),
+        // we can make shares_to_burn floor to 0.
+        //
+        // Simulate inflated asset pool: 10_000 assets, 10 shares.
+        let id2 = env.register_contract(None, WithdrawRoundingVault);
+        let c2 = WithdrawRoundingVaultClient::new(&env, &id2);
+        c2.initialize(&10_000, &10); // share price = 1000 assets/share
+        let u2 = Address::generate(&env);
+        c2.seed_shares(&u2, &10);
+
+        let shares_before = c2.shares_of(&u2);
+        let assets_before = c2.total_assets();
+
+        // Withdraw 1 asset: shares_to_burn = 1 * 10 / 10_000 = 0 (floors).
+        c2.withdraw(&u2, &1);
+
+        assert_eq!(c2.shares_of(&u2), shares_before, "no shares burned");
+        assert_eq!(c2.total_assets(), assets_before - 1, "assets decreased");
+    }
+
+    /// Boundary: withdrawal that burns zero shares is accepted by the vulnerable contract.
+    #[test]
+    fn test_zero_burn_withdrawal_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, WithdrawRoundingVault);
+        let client = WithdrawRoundingVaultClient::new(&env, &id);
+        client.initialize(&10_000, &10);
+        let user = Address::generate(&env);
+        client.seed_shares(&user, &10);
+
+        // shares_to_burn = 1 * 10 / 10_000 = 0 — should be rejected but isn't.
+        client.withdraw(&user, &1);
+        assert_eq!(client.shares_of(&user), 10, "shares unchanged after zero-burn withdrawal");
+    }
+
+    /// SECURE: withdrawal that would burn zero shares is rejected.
+    #[test]
+    #[should_panic(expected = "withdrawal burns zero shares")]
+    fn test_secure_rejects_zero_burn_withdrawal() {
+        use crate::secure::SecureVaultClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureVault);
+        let client = SecureVaultClient::new(&env, &id);
+        env.mock_all_auths();
+        client.initialize(&10_000, &10);
+        let user = Address::generate(&env);
+        client.seed_shares(&user, &10);
+
+        client.withdraw(&user, &1);
+    }
+
+    /// SECURE: proportional withdrawal burns the correct (ceiling) number of shares.
+    #[test]
+    fn test_secure_proportional_withdrawal() {
+        use crate::secure::SecureVaultClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureVault);
+        let client = SecureVaultClient::new(&env, &id);
+        env.mock_all_auths();
+        // 1000 assets, 1000 shares → 1:1.
+        client.initialize(&1000, &1000);
+        let user = Address::generate(&env);
+        client.seed_shares(&user, &500);
+
+        client.withdraw(&user, &100);
+        // 100 * 1000 / 1000 = 100 shares burned (exact, ceiling == floor here).
+        assert_eq!(client.shares_of(&user), 400);
+        assert_eq!(client.total_assets(), 900);
+    }
+}

--- a/vulnerable/withdraw_rounding_leak/src/secure.rs
+++ b/vulnerable/withdraw_rounding_leak/src/secure.rs
@@ -1,0 +1,68 @@
+//! SECURE mirror: round shares_to_burn up (ceiling division) and reject zero-burn withdrawals.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureVault;
+
+#[contractimpl]
+impl SecureVault {
+    pub fn initialize(env: Env, seed_assets: i128, seed_shares: i128) {
+        assert!(seed_assets > 0 && seed_shares > 0, "seed must be positive");
+        if env.storage().persistent().has(&DataKey::TotalAssets) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::TotalAssets, &seed_assets);
+        env.storage().persistent().set(&DataKey::TotalShares, &seed_shares);
+    }
+
+    pub fn seed_shares(env: Env, user: Address, shares: i128) {
+        env.storage().persistent().set(&DataKey::Shares(user), &shares);
+    }
+
+    /// ✅ Ceiling division: `(a + b - 1) / b` rounds shares_to_burn up.
+    pub fn withdraw(env: Env, user: Address, assets: i128) {
+        user.require_auth();
+        assert!(assets > 0, "assets must be positive");
+
+        let total_assets: i128 = env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(1);
+        let total_shares: i128 = env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(1);
+
+        // ✅ Ceiling division — withdrawer cannot pay fewer shares than proportional.
+        let shares_to_burn = (assets * total_shares + total_assets - 1) / total_assets;
+        assert!(shares_to_burn > 0, "withdrawal burns zero shares");
+
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Shares(user.clone()))
+            .unwrap_or(0);
+        assert!(current >= shares_to_burn, "insufficient shares");
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(user), &(current - shares_to_burn));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(total_assets - assets));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(total_shares - shares_to_burn));
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Shares(user))
+            .unwrap_or(0)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(0)
+    }
+
+    pub fn total_assets(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(0)
+    }
+}

--- a/vulnerable/zero_share_rounding/Cargo.toml
+++ b/vulnerable/zero_share_rounding/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "zero-share-rounding"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban vault: deposit accepted even when computed shares round to zero"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/zero_share_rounding/src/lib.rs
+++ b/vulnerable/zero_share_rounding/src/lib.rs
@@ -1,0 +1,147 @@
+//! VULNERABLE: Zero-Share Rounding
+//!
+//! A vault that calculates shares as `amount * total_shares / total_assets`.
+//! When `total_assets` is large relative to `amount`, integer division floors
+//! the result to zero.  The deposit is accepted, the user loses their tokens,
+//! and `total_assets` grows without a matching share issuance — diluting all
+//! other depositors.
+//!
+//! VULNERABILITY: `deposit` does not check that `shares_minted > 0` before
+//! crediting the depositor.
+//!
+//! SEVERITY: Medium
+//!
+//! SECURE MIRROR: `secure::SecureVault` panics with "deposit mints zero shares"
+//! when the computed share amount is zero.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    TotalAssets,
+    TotalShares,
+    Shares(Address),
+}
+
+#[contract]
+pub struct ZeroShareVault;
+
+#[contractimpl]
+impl ZeroShareVault {
+    pub fn initialize(env: Env, seed_assets: i128, seed_shares: i128) {
+        assert!(seed_assets > 0 && seed_shares > 0, "seed must be positive");
+        if env.storage().persistent().has(&DataKey::TotalAssets) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::TotalAssets, &seed_assets);
+        env.storage().persistent().set(&DataKey::TotalShares, &seed_shares);
+    }
+
+    /// VULNERABLE: accepts the deposit even when `shares_minted` rounds to zero.
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let total_assets: i128 = env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(1);
+        let total_shares: i128 = env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(1);
+
+        // ❌ Integer division floors to zero when amount << total_assets / total_shares.
+        let shares_minted = amount * total_shares / total_assets;
+
+        // ❌ Missing: assert!(shares_minted > 0, "deposit mints zero shares");
+
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Shares(user.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(user), &(current + shares_minted));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(total_assets + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(total_shares + shares_minted));
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Shares(user))
+            .unwrap_or(0)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(0)
+    }
+
+    pub fn total_assets(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup(env: &Env) -> ZeroShareVaultClient {
+        let id = env.register_contract(None, ZeroShareVault);
+        let client = ZeroShareVaultClient::new(env, &id);
+        env.mock_all_auths();
+        // Seed: 1_000_000 assets, 1_000 shares → share price = 1000 assets/share.
+        client.initialize(&1_000_000, &1_000);
+        client
+    }
+
+    /// DEMONSTRATES VULNERABILITY: tiny deposit mints zero shares, user loses funds.
+    #[test]
+    fn test_zero_shares_minted_on_tiny_deposit() {
+        let env = Env::default();
+        let client = setup(&env);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+        // 1 asset deposited; share price is 1000 → shares = 1 * 1000 / 1_000_000 = 0.
+        client.deposit(&user, &1);
+
+        assert_eq!(client.shares_of(&user), 0, "user received zero shares");
+        // But total_assets grew — user's deposit was absorbed with no shares issued.
+        assert_eq!(client.total_assets(), 1_000_001);
+    }
+
+    /// Boundary: deposit just below the share-price threshold also yields zero shares.
+    #[test]
+    fn test_deposit_below_threshold_yields_zero_shares() {
+        let env = Env::default();
+        let client = setup(&env);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+        // 999 assets → 999 * 1000 / 1_000_000 = 0 (floors).
+        client.deposit(&user, &999);
+        assert_eq!(client.shares_of(&user), 0);
+    }
+
+    /// SECURE: deposit that mints zero shares is rejected.
+    #[test]
+    #[should_panic(expected = "deposit mints zero shares")]
+    fn test_secure_rejects_zero_share_deposit() {
+        use crate::secure::SecureVaultClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureVault);
+        let client = SecureVaultClient::new(&env, &id);
+        env.mock_all_auths();
+        client.initialize(&1_000_000, &1_000);
+
+        let user = Address::generate(&env);
+        client.deposit(&user, &1);
+    }
+}

--- a/vulnerable/zero_share_rounding/src/secure.rs
+++ b/vulnerable/zero_share_rounding/src/secure.rs
@@ -1,0 +1,62 @@
+//! SECURE mirror: reject deposits that would mint zero shares.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureVault;
+
+#[contractimpl]
+impl SecureVault {
+    pub fn initialize(env: Env, seed_assets: i128, seed_shares: i128) {
+        assert!(seed_assets > 0 && seed_shares > 0, "seed must be positive");
+        if env.storage().persistent().has(&DataKey::TotalAssets) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::TotalAssets, &seed_assets);
+        env.storage().persistent().set(&DataKey::TotalShares, &seed_shares);
+    }
+
+    /// ✅ Panics when integer division would mint zero shares.
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let total_assets: i128 = env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(1);
+        let total_shares: i128 = env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(1);
+
+        let shares_minted = amount * total_shares / total_assets;
+        // ✅ Guard: reject deposits that produce no shares.
+        assert!(shares_minted > 0, "deposit mints zero shares");
+
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Shares(user.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Shares(user), &(current + shares_minted));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalAssets, &(total_assets + amount));
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalShares, &(total_shares + shares_minted));
+    }
+
+    pub fn shares_of(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Shares(user))
+            .unwrap_or(0)
+    }
+
+    pub fn total_shares(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalShares).unwrap_or(0)
+    }
+
+    pub fn total_assets(env: Env) -> i128 {
+        env.storage().persistent().get(&DataKey::TotalAssets).unwrap_or(0)
+    }
+}


### PR DESCRIPTION
closes #231 
closes #232 
closes #233 
closes #234 

# feat: add four new vulnerable/secure fixture crates

## Summary

Adds four focused Soroban scanner-fixture crates, each with a vulnerable
implementation (`src/lib.rs`), a secure mirror (`src/secure.rs`), and a
full test suite covering the unsafe path, the boundary condition, and the
secure rejection.

---

## Commits

| SHA | Crate | Severity |
|---|---|---|
| `3de754c` | `vulnerable/unchecked_fee_collector` | High |
| `694535f` | `vulnerable/untrusted_oracle_setter` | Critical |
| `435d56f` | `vulnerable/zero_share_rounding` | Medium |
| `2d37301` | `vulnerable/withdraw_rounding_leak` | High |

---

## Changes

### `vulnerable/unchecked_fee_collector` — High

**Vulnerability:** `set_collector` stores any caller-supplied address as the
fee collector without requiring admin authorisation or validating the address
against an approved list. Fees can be silently redirected to an
attacker-controlled address or trapped in an address incapable of receiving
tokens.

**Vulnerable pattern:**
```rust
pub fn set_collector(env: Env, collector: Address) {
    // ❌ No admin.require_auth()
    // ❌ No allowlist check
    env.storage().persistent().set(&DataKey::Collector, &collector);
}
```

**Secure fix:** admin `require_auth()` + approved-list assertion before
storing the collector address.

**Tests:**
- `test_attacker_redirects_collector` — attacker sets themselves as collector and drains fees
- `test_any_address_accepted_as_collector` — boundary: any address is silently accepted
- `test_secure_rejects_unapproved_collector` — secure path panics on unapproved address
- `test_secure_accepts_approved_collector` — secure path accepts an allowlisted address

---

### `vulnerable/untrusted_oracle_setter` — Critical

**Vulnerability:** `set_oracle` stores any caller-supplied address without
admin authorisation or allowlist validation. A malicious oracle can return
inflated prices, enabling over-collateralised borrows or sandwich attacks
against any contract that reads the stored oracle.

**Vulnerable pattern:**
```rust
pub fn set_oracle(env: Env, oracle: Address) {
    // ❌ No admin.require_auth()
    // ❌ No allowlist check
    env.storage().persistent().set(&DataKey::Oracle, &oracle);
}
```

**Secure fix:** admin `require_auth()` + allowlist check before storing the
oracle address.

**Tests:**
- `test_malicious_oracle_inflates_price` — attacker injects an inflated price via a malicious oracle
- `test_arbitrary_address_accepted` — boundary: address with no price data silently returns 0
- `test_secure_rejects_non_allowlisted_oracle` — secure path panics on non-allowlisted oracle
- `test_secure_accepts_allowlisted_oracle` — secure path accepts an allowlisted oracle

---

### `vulnerable/zero_share_rounding` — Medium

**Vulnerability:** `deposit` accepts funds even when
`amount * total_shares / total_assets` floors to zero due to integer
division. The user loses their tokens silently and `total_assets` grows
without a matching share issuance, diluting all other depositors.

**Vulnerable pattern:**
```rust
let shares_minted = amount * total_shares / total_assets;
// ❌ Missing: assert!(shares_minted > 0, "deposit mints zero shares");
```

**Secure fix:** assert `shares_minted > 0` before crediting the depositor or
updating pool state.

**Tests:**
- `test_zero_shares_minted_on_tiny_deposit` — 1-asset deposit against a 1 000 000-asset pool mints 0 shares
- `test_deposit_below_threshold_yields_zero_shares` — boundary: 999-asset deposit also floors to 0
- `test_secure_rejects_zero_share_deposit` — secure path panics with `"deposit mints zero shares"`

---

### `vulnerable/withdraw_rounding_leak` — High

**Vulnerability:** `withdraw` computes `shares_to_burn` with floor division,
rounding in favour of the withdrawer. Repeated small withdrawals extract
assets while burning fewer shares than the proportional amount, slowly
draining value from other depositors. Withdrawals that compute to zero
shares burned are also silently accepted.

**Vulnerable pattern:**
```rust
// ❌ Floor division — withdrawer pays fewer shares than they should.
let shares_to_burn = assets * total_shares / total_assets;
// ❌ Missing: assert!(shares_to_burn > 0, "withdrawal burns zero shares");
```

**Secure fix:** ceiling division `(assets * total_shares + total_assets - 1) / total_assets`
plus a zero-burn guard.

**Tests:**
- `test_repeated_withdrawals_drain_assets_without_burning_shares` — assets decrease while share balance stays constant
- `test_zero_burn_withdrawal_accepted` — boundary: 1-asset withdrawal burns 0 shares in the vulnerable path
- `test_secure_rejects_zero_burn_withdrawal` — secure path panics with `"withdrawal burns zero shares"`
- `test_secure_proportional_withdrawal` — secure path burns the exact ceiling share count

---

## Files changed

```
Cargo.toml                                        (workspace members +4)
vulnerable/unchecked_fee_collector/Cargo.toml
vulnerable/unchecked_fee_collector/src/lib.rs
vulnerable/unchecked_fee_collector/src/secure.rs
vulnerable/untrusted_oracle_setter/Cargo.toml
vulnerable/untrusted_oracle_setter/src/lib.rs
vulnerable/untrusted_oracle_setter/src/secure.rs
vulnerable/zero_share_rounding/Cargo.toml
vulnerable/zero_share_rounding/src/lib.rs
vulnerable/zero_share_rounding/src/secure.rs
vulnerable/withdraw_rounding_leak/Cargo.toml
vulnerable/withdraw_rounding_leak/src/lib.rs
vulnerable/withdraw_rounding_leak/src/secure.rs
```

---

## Checklist

- [x] Each crate registered in workspace `Cargo.toml`
- [x] Vulnerable path is reachable and scannable
- [x] Secure mirror demonstrates the correct fix
- [x] Tests cover: unsafe path, boundary condition, secure rejection
- [x] No `std` outside test modules (`#![no_std]` on all lib crates)
- [x] One commit per issue

