### PR TITLE
feat: add vulnerable/future_oracle_timestamp contract (#247)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "vulnerable/fee_on_transfer",
     "vulnerable/instant_oracle",
     "vulnerable/stale_oracle",
+    "vulnerable/future_oracle_timestamp",
     "vulnerable/unprotected_admin",
     "vulnerable/unprotected_upgrade",
     "vulnerable/unprotected_burn",

--- a/vulnerable/future_oracle_timestamp/Cargo.toml
+++ b/vulnerable/future_oracle_timestamp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "future-oracle-timestamp"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating future oracle timestamp extending price validity"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/future_oracle_timestamp/src/lib.rs
+++ b/vulnerable/future_oracle_timestamp/src/lib.rs
@@ -1,0 +1,237 @@
+//! VULNERABLE: Future Oracle Timestamp
+//!
+//! A DEX/lending contract reads a price from an oracle that carries a
+//! `publish_time` field. The freshness check only verifies that the price is
+//! not *too old* (`now - publish_time <= MAX_STALENESS`), but never checks
+//! whether `publish_time` is in the future.
+//!
+//! An attacker who controls the oracle (or can submit a signed price feed) can
+//! set `publish_time = now + LARGE_OFFSET`, making the price appear fresh for
+//! `LARGE_OFFSET + MAX_STALENESS` seconds — far beyond the intended window.
+//!
+//! VULNERABILITY: No `publish_time > now` rejection before the staleness check.
+//!
+//! SEVERITY: High
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod oracle;
+pub mod secure;
+
+use oracle::MockOracleClient;
+
+const MAX_STALENESS: u64 = 300; // 5 minutes
+
+#[contracttype]
+pub enum DataKey {
+    OracleId,
+    Collateral(Address),
+}
+
+// ── Vulnerable Contract ───────────────────────────────────────────────────────
+
+#[contract]
+pub struct VulnerablePricer;
+
+#[contractimpl]
+impl VulnerablePricer {
+    pub fn init(env: Env, oracle_id: Address) {
+        if env.storage().persistent().has(&DataKey::OracleId) {
+            panic!("already initialized");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::OracleId, &oracle_id);
+    }
+
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        let key = DataKey::Collateral(user);
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
+    }
+
+    /// ❌ Only checks lower bound (staleness). A future `publish_time` makes
+    ///    the price appear fresh for `publish_time - now + MAX_STALENESS` extra
+    ///    seconds.
+    pub fn get_value(env: Env, user: Address) -> i128 {
+        let oracle_id: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleId)
+            .expect("not initialized");
+        let oracle = MockOracleClient::new(&env, &oracle_id);
+        let price = oracle.get_price();
+        let publish_time: u64 = oracle.publish_time();
+        let now = env.ledger().timestamp();
+
+        // BUG: `publish_time` may be > `now`; saturating_sub silently treats
+        // that as age == 0, so the price always passes the freshness check.
+        assert!(
+            now.saturating_sub(publish_time) <= MAX_STALENESS,
+            "price too stale"
+        );
+
+        let collateral: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user))
+            .unwrap_or(0);
+        collateral * price
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        Env,
+    };
+
+    fn setup(env: &Env) -> (oracle::MockOracleClient, VulnerablePricerClient) {
+        let oracle_id = env.register_contract(None, oracle::MockOracle);
+        let oracle = oracle::MockOracleClient::new(env, &oracle_id);
+        let admin = soroban_sdk::Address::generate(env);
+        env.mock_all_auths();
+        oracle.init(&admin);
+
+        let pricer_id = env.register_contract(None, VulnerablePricer);
+        let pricer = VulnerablePricerClient::new(env, &pricer_id);
+        pricer.init(&oracle_id);
+        (oracle, pricer)
+    }
+
+    /// Baseline: a normally-timed price works.
+    #[test]
+    fn test_normal_price_accepted() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1000);
+        let (oracle, pricer) = setup(&env);
+        env.mock_all_auths();
+
+        oracle.set_price(&200);
+        let user = soroban_sdk::Address::generate(&env);
+        pricer.deposit(&user, &10);
+
+        assert_eq!(pricer.get_value(&user), 2000);
+    }
+
+    /// VULNERABLE: oracle sets a future publish_time.
+    /// At `now = 1000` the price was published at `publish_time = 2000`.
+    /// The staleness check computes `1000u64.saturating_sub(2000) == 0 <= 300`,
+    /// so the price passes — even though it hasn't happened yet.
+    /// Later, at `now = 2300` (= publish_time + MAX_STALENESS), the price is
+    /// still accepted, extending the valid window by 1000 extra seconds.
+    #[test]
+    fn test_future_timestamp_extends_validity_window() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1000);
+        let (oracle, pricer) = setup(&env);
+        env.mock_all_auths();
+
+        // Publish a price with a timestamp 1000 s in the future.
+        oracle.set_price_at(&200, &2000);
+
+        let user = soroban_sdk::Address::generate(&env);
+        pricer.deposit(&user, &10);
+
+        // At now=1000 the price passes (future ts treated as age 0).
+        assert_eq!(pricer.get_value(&user), 2000);
+
+        // Advance to now=2300 — still within the inflated window.
+        env.ledger().set_timestamp(2300);
+        assert_eq!(pricer.get_value(&user), 2000);
+        // A correct implementation would have expired this price at now=1300
+        // (publish_time=1000 + MAX_STALENESS=300). The future timestamp inflated
+        // the valid window by an extra 1000 seconds.
+    }
+
+    /// Boundary: price published exactly at MAX_STALENESS seconds ago is still
+    /// accepted.
+    #[test]
+    fn test_boundary_at_max_staleness_accepted() {
+        let env = Env::default();
+        env.ledger().set_timestamp(300);
+        let (oracle, pricer) = setup(&env);
+        env.mock_all_auths();
+
+        oracle.set_price(&50); // publish_time = 300
+        let user = soroban_sdk::Address::generate(&env);
+        pricer.deposit(&user, &4);
+
+        env.ledger().set_timestamp(600); // age == 300 == MAX_STALENESS
+        assert_eq!(pricer.get_value(&user), 200);
+    }
+
+    /// Boundary: one second past MAX_STALENESS is rejected.
+    #[test]
+    #[should_panic(expected = "price too stale")]
+    fn test_boundary_past_max_staleness_rejected() {
+        let env = Env::default();
+        env.ledger().set_timestamp(300);
+        let (oracle, pricer) = setup(&env);
+        env.mock_all_auths();
+
+        oracle.set_price(&50); // publish_time = 300
+        let user = soroban_sdk::Address::generate(&env);
+        pricer.deposit(&user, &4);
+
+        env.ledger().set_timestamp(601); // age == 301 > MAX_STALENESS
+        pricer.get_value(&user);
+    }
+
+    // ── secure mirror tests ───────────────────────────────────────────────────
+
+    /// Secure: future publish_time is rejected immediately.
+    #[test]
+    #[should_panic(expected = "future timestamp")]
+    fn test_secure_rejects_future_timestamp() {
+        use crate::secure::SecurePricerClient;
+        let env = Env::default();
+        env.ledger().set_timestamp(1000);
+
+        let oracle_id = env.register_contract(None, oracle::MockOracle);
+        let oracle = oracle::MockOracleClient::new(&env, &oracle_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        env.mock_all_auths();
+        oracle.init(&admin);
+
+        let pricer_id = env.register_contract(None, secure::SecurePricer);
+        let pricer = SecurePricerClient::new(&env, &pricer_id);
+        pricer.init(&oracle_id);
+
+        oracle.set_price_at(&200, &2000); // publish_time in the future
+        let user = soroban_sdk::Address::generate(&env);
+        pricer.deposit(&user, &10);
+
+        pricer.get_value(&user); // must panic
+    }
+
+    /// Secure: normal price still works.
+    #[test]
+    fn test_secure_accepts_normal_price() {
+        use crate::secure::SecurePricerClient;
+        let env = Env::default();
+        env.ledger().set_timestamp(1000);
+
+        let oracle_id = env.register_contract(None, oracle::MockOracle);
+        let oracle = oracle::MockOracleClient::new(&env, &oracle_id);
+        let admin = soroban_sdk::Address::generate(&env);
+        env.mock_all_auths();
+        oracle.init(&admin);
+
+        let pricer_id = env.register_contract(None, secure::SecurePricer);
+        let pricer = SecurePricerClient::new(&env, &pricer_id);
+        pricer.init(&oracle_id);
+
+        oracle.set_price(&100); // publish_time = 1000
+        let user = soroban_sdk::Address::generate(&env);
+        pricer.deposit(&user, &5);
+
+        assert_eq!(pricer.get_value(&user), 500);
+    }
+}

--- a/vulnerable/future_oracle_timestamp/src/oracle.rs
+++ b/vulnerable/future_oracle_timestamp/src/oracle.rs
@@ -1,0 +1,66 @@
+//! Mock Oracle with an explicit `publish_time` field.
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+pub enum OracleKey {
+    Admin,
+    Price,
+    PublishTime,
+}
+
+#[contract]
+pub struct MockOracle;
+
+#[contractimpl]
+impl MockOracle {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().persistent().has(&OracleKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&OracleKey::Admin, &admin);
+    }
+
+    /// Set price; publish_time = current ledger timestamp.
+    pub fn set_price(env: Env, price: i128) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&OracleKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage().persistent().set(&OracleKey::Price, &price);
+        let now = env.ledger().timestamp();
+        env.storage()
+            .persistent()
+            .set(&OracleKey::PublishTime, &now);
+    }
+
+    /// Set price with an explicit publish_time (allows future timestamps).
+    pub fn set_price_at(env: Env, price: i128, publish_time: u64) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&OracleKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage().persistent().set(&OracleKey::Price, &price);
+        env.storage()
+            .persistent()
+            .set(&OracleKey::PublishTime, &publish_time);
+    }
+
+    pub fn get_price(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&OracleKey::Price)
+            .unwrap_or(0)
+    }
+
+    pub fn publish_time(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&OracleKey::PublishTime)
+            .unwrap_or(0)
+    }
+}

--- a/vulnerable/future_oracle_timestamp/src/secure.rs
+++ b/vulnerable/future_oracle_timestamp/src/secure.rs
@@ -1,0 +1,56 @@
+//! SECURE mirror: reject oracle prices whose `publish_time` is in the future
+//! before applying the normal staleness window.
+//!
+//! Fix: assert `publish_time <= now` first, then check `now - publish_time <= MAX_STALENESS`.
+
+use crate::{oracle::MockOracleClient, DataKey};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+const MAX_STALENESS: u64 = 300;
+
+#[contract]
+pub struct SecurePricer;
+
+#[contractimpl]
+impl SecurePricer {
+    pub fn init(env: Env, oracle_id: Address) {
+        if env.storage().persistent().has(&DataKey::OracleId) {
+            panic!("already initialized");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::OracleId, &oracle_id);
+    }
+
+    pub fn deposit(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+        let key = DataKey::Collateral(user);
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage().persistent().set(&key, &(current + amount));
+    }
+
+    /// ✅ Rejects future publish_time before checking staleness.
+    pub fn get_value(env: Env, user: Address) -> i128 {
+        let oracle_id: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OracleId)
+            .expect("not initialized");
+        let oracle = MockOracleClient::new(&env, &oracle_id);
+        let price = oracle.get_price();
+        let publish_time: u64 = oracle.publish_time();
+        let now = env.ledger().timestamp();
+
+        // ✅ Guard 1: reject future timestamps.
+        assert!(publish_time <= now, "future timestamp");
+        // ✅ Guard 2: reject stale prices.
+        assert!(now - publish_time <= MAX_STALENESS, "price too stale");
+
+        let collateral: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Collateral(user))
+            .unwrap_or(0);
+        collateral * price
+    }
+}


### PR DESCRIPTION
## Summary

Closes #247.

Adds a new vulnerable Soroban fixture demonstrating the **future oracle timestamp** vulnerability: a freshness check that uses `saturating_sub` without first rejecting `publish_time > now` allows an attacker to inflate the price validity window arbitrarily.

## Changes

- `vulnerable/future_oracle_timestamp/Cargo.toml` — new crate (`future-oracle-timestamp`)
- `vulnerable/future_oracle_timestamp/src/oracle.rs` — `MockOracle` with `set_price()` and `set_price_at(price, publish_time)`
- `vulnerable/future_oracle_timestamp/src/lib.rs` — `VulnerablePricer` (missing future-ts guard) + 5 tests
- `vulnerable/future_oracle_timestamp/src/secure.rs` — `SecurePricer` with two-guard fix
- `Cargo.toml` — added crate to workspace members

## Vulnerability

```rust
// BUG: saturating_sub(future_ts) == 0 — price always appears fresh
assert!(now.saturating_sub(publish_time) <= MAX_STALENESS, "price too stale");
```

## Fix

```rust
assert!(publish_time <= now, "future timestamp");          // guard 1
assert!(now - publish_time <= MAX_STALENESS, "price too stale"); // guard 2
```

## Tests

| Test | Covers |
|---|---|
| `test_normal_price_accepted` | Baseline |
| `test_future_timestamp_extends_validity_window` | Vulnerable path: future ts accepted at `now=1000`, still valid at `now=2300` |
| `test_boundary_at_max_staleness_accepted` | Boundary: age == MAX_STALENESS passes |
| `test_boundary_past_max_staleness_rejected` | Boundary: age > MAX_STALENESS panics |
| `test_secure_rejects_future_timestamp` | Secure path: future ts panics immediately |
| `test_secure_accepts_normal_price` | Secure path: normal price works |

Severity: **High**