### PR TITLE
feat: add fake token registration vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "vulnerable/mixed_collateral_decimals",
     "vulnerable/signed_unsigned_wrap",
     "vulnerable/abs_min_overflow",
+    "vulnerable/fake_token_registration",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/fake_token_registration/Cargo.toml
+++ b/vulnerable/fake_token_registration/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fake-token-registration"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating fake token registration with untrusted metadata"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/fake_token_registration/README.md
+++ b/vulnerable/fake_token_registration/README.md
@@ -1,0 +1,123 @@
+# Fake Token Registration
+
+## Vulnerability
+
+An asset registry that trusts caller-supplied symbol and decimals metadata without verification. Attackers can register fake assets that look identical to trusted tokens in downstream views, enabling phishing attacks and user confusion.
+
+## Severity
+
+**High**
+
+## Description
+
+The vulnerable contract allows anyone to register a token with arbitrary metadata (symbol, decimals) without:
+1. Admin approval
+2. Verification against the actual token contract
+3. Checking for duplicate symbols
+
+This enables attackers to:
+- Register malicious tokens with trusted symbols (e.g., "USDC", "XLM")
+- Create multiple tokens with the same symbol, causing confusion
+- Phish users who trust the registry's metadata
+
+## Vulnerable Code
+
+```rust
+pub fn register_token(
+    env: Env,
+    token_address: Address,
+    symbol: String,
+    decimals: u32,
+    caller: Address,
+) {
+    caller.require_auth();
+
+    // ❌ Missing: Admin approval check
+    // ❌ Missing: Verification of symbol/decimals against token contract
+    // ❌ Missing: Check for duplicate symbols
+
+    let metadata = TokenMetadata {
+        token_address: token_address.clone(),
+        symbol,
+        decimals,
+        registered_by: caller,
+        timestamp: env.ledger().timestamp(),
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Token(token_address), &metadata);
+}
+```
+
+## Attack Scenario
+
+1. Attacker deploys a malicious token contract
+2. Attacker calls `register_token()` with:
+   - `token_address`: their malicious contract
+   - `symbol`: "USDC" (or any trusted token symbol)
+   - `decimals`: 6 (matching the real USDC)
+3. Users query the registry and see "USDC" with correct decimals
+4. Users trust the metadata and interact with the fake token
+5. Attacker drains user funds or executes other malicious actions
+
+## Secure Fix
+
+The secure implementation (`src/secure.rs`) fixes this by:
+
+1. **Admin-only registration**: Only the admin can register tokens
+2. **Duplicate symbol check**: Prevents multiple tokens with the same symbol
+3. **Symbol mapping**: Maintains a symbol → address mapping for quick lookups
+
+```rust
+pub fn register_token(
+    env: Env,
+    token_address: Address,
+    symbol: String,
+    decimals: u32,
+) {
+    // ✅ Require admin authorization
+    Self::require_admin(&env);
+
+    // ✅ Check if token is already registered
+    if env.storage().persistent().has(&DataKey::Token(token_address.clone())) {
+        panic!("token already registered");
+    }
+
+    // ✅ Check for duplicate symbols
+    if Self::symbol_exists(&env, &symbol) {
+        panic!("symbol already in use");
+    }
+
+    // ... rest of implementation
+}
+```
+
+## Additional Recommendations
+
+1. **Token interface verification**: If the token implements a standard interface (e.g., SEP-41), query the symbol and decimals directly from the token contract and verify they match the provided values
+2. **Whitelist approach**: Maintain a curated list of approved tokens rather than allowing arbitrary registration
+3. **Multi-sig approval**: Require multiple admin signatures for token registration
+4. **Time-lock**: Add a delay between registration and activation to allow for review
+5. **Event emission**: Emit events for all registration actions for off-chain monitoring
+
+## Testing
+
+Run the tests to see the vulnerability in action:
+
+```bash
+cargo test -p fake-token-registration
+```
+
+Key tests:
+- `test_fake_token_registration_succeeds`: Demonstrates successful fake token registration
+- `test_duplicate_symbol_allowed`: Shows multiple tokens can have the same symbol
+- `test_no_admin_approval_required`: Proves anyone can register tokens
+- `test_secure_requires_admin_approval`: Secure version requires admin auth
+- `test_secure_rejects_duplicate_symbols`: Secure version prevents duplicate symbols
+
+## References
+
+- [CWE-345: Insufficient Verification of Data Authenticity](https://cwe.mitre.org/data/definitions/345.html)
+- [CWE-290: Authentication Bypass by Spoofing](https://cwe.mitre.org/data/definitions/290.html)
+- Stellar SEP-41: Token Interface Standard

--- a/vulnerable/fake_token_registration/src/lib.rs
+++ b/vulnerable/fake_token_registration/src/lib.rs
@@ -1,0 +1,325 @@
+//! VULNERABLE: Fake Token Registration
+//!
+//! An asset registry that trusts caller-supplied symbol and decimals metadata.
+//! Attackers can register fake assets that look identical to trusted tokens
+//! in downstream views, enabling phishing attacks and user confusion.
+//!
+//! VULNERABILITY: Asset metadata (symbol, decimals) is stored from untrusted
+//! caller arguments without verification against the actual token contract.
+//! Severity: High
+//!
+//! Attack scenario:
+//! 1. Attacker deploys a malicious token contract
+//! 2. Attacker registers it with symbol="USDC" and decimals=6
+//! 3. Users see "USDC" in the registry and trust it
+//! 4. Users interact with the fake token, losing funds
+//!
+//! Secure fix: Require admin approval for token registration and verify
+//! metadata through the token interface where possible.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
+
+pub mod secure;
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenMetadata {
+    pub token_address: Address,
+    pub symbol: String,
+    pub decimals: u32,
+    pub registered_by: Address,
+    pub timestamp: u64,
+}
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Token(Address), // Maps token address -> TokenMetadata
+    Symbol(String), // Maps symbol -> token address (used in secure version)
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct VulnerableTokenRegistry;
+
+#[contractimpl]
+impl VulnerableTokenRegistry {
+    /// Initialize the registry with an admin address. Guards against re-init.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// VULNERABLE: Registers a token with caller-supplied metadata.
+    /// ❌ BUG: No verification that the symbol and decimals match the actual
+    /// token contract. An attacker can register a malicious token with a
+    /// trusted symbol like "USDC" or "XLM".
+    pub fn register_token(
+        env: Env,
+        token_address: Address,
+        symbol: String,
+        decimals: u32,
+        caller: Address,
+    ) {
+        caller.require_auth();
+
+        // ❌ Missing: Admin approval check
+        // ❌ Missing: Verification of symbol/decimals against token contract
+        // ❌ Missing: Check for duplicate symbols
+
+        let metadata = TokenMetadata {
+            token_address: token_address.clone(),
+            symbol,
+            decimals,
+            registered_by: caller,
+            timestamp: env.ledger().timestamp(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(token_address), &metadata);
+    }
+
+    /// Returns the metadata for a registered token, or None if not found.
+    pub fn get_token(env: Env, token_address: Address) -> Option<TokenMetadata> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Token(token_address))
+    }
+
+    /// Returns true if a token is registered.
+    pub fn is_registered(env: Env, token_address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Token(token_address))
+    }
+
+    /// Admin can remove a token from the registry (e.g., after discovering it's fake).
+    pub fn remove_token(env: Env, token_address: Address) {
+        Self::require_admin(&env);
+        env.storage().persistent().remove(&DataKey::Token(token_address));
+    }
+
+    fn require_admin(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    fn setup() -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, VulnerableTokenRegistry);
+        let admin = Address::generate(&env);
+        VulnerableTokenRegistryClient::new(&env, &contract_id).initialize(&admin);
+        (env, contract_id, admin)
+    }
+
+    /// Demonstrates the vulnerability: an attacker registers a fake token
+    /// with a trusted symbol (e.g., "USDC") and the registry accepts it.
+    #[test]
+    fn test_fake_token_registration_succeeds() {
+        let (env, contract_id, _admin) = setup();
+        let client = VulnerableTokenRegistryClient::new(&env, &contract_id);
+
+        let attacker = Address::generate(&env);
+        let fake_token = Address::generate(&env);
+
+        // Attacker registers their malicious token as "USDC" with 6 decimals
+        client.register_token(
+            &fake_token,
+            &String::from_str(&env, "USDC"),
+            &6u32,
+            &attacker,
+        );
+
+        // The fake token is now in the registry with trusted metadata
+        let metadata = client.get_token(&fake_token).unwrap();
+        assert_eq!(metadata.symbol, String::from_str(&env, "USDC"));
+        assert_eq!(metadata.decimals, 6);
+        assert_eq!(metadata.registered_by, attacker);
+        assert!(client.is_registered(&fake_token));
+    }
+
+    /// Demonstrates that multiple tokens can be registered with the same symbol,
+    /// creating confusion for users.
+    #[test]
+    fn test_duplicate_symbol_allowed() {
+        let (env, contract_id, _admin) = setup();
+        let client = VulnerableTokenRegistryClient::new(&env, &contract_id);
+
+        let attacker1 = Address::generate(&env);
+        let attacker2 = Address::generate(&env);
+        let fake_token1 = Address::generate(&env);
+        let fake_token2 = Address::generate(&env);
+
+        // Both attackers register different tokens with the same symbol
+        client.register_token(
+            &fake_token1,
+            &String::from_str(&env, "USDC"),
+            &6u32,
+            &attacker1,
+        );
+        client.register_token(
+            &fake_token2,
+            &String::from_str(&env, "USDC"),
+            &6u32,
+            &attacker2,
+        );
+
+        // Both fake tokens are registered with identical symbols
+        let metadata1 = client.get_token(&fake_token1).unwrap();
+        let metadata2 = client.get_token(&fake_token2).unwrap();
+        assert_eq!(metadata1.symbol, metadata2.symbol);
+        assert_eq!(metadata1.symbol, String::from_str(&env, "USDC"));
+    }
+
+    /// Demonstrates that anyone can register a token without admin approval.
+    #[test]
+    fn test_no_admin_approval_required() {
+        let (env, contract_id, _admin) = setup();
+        let client = VulnerableTokenRegistryClient::new(&env, &contract_id);
+
+        let random_user = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        // Any user can register a token
+        client.register_token(
+            &token,
+            &String::from_str(&env, "SCAM"),
+            &18u32,
+            &random_user,
+        );
+
+        assert!(client.is_registered(&token));
+    }
+
+    /// Admin can remove a fake token after discovering it.
+    #[test]
+    fn test_admin_can_remove_token() {
+        let (env, contract_id, _admin) = setup();
+        let client = VulnerableTokenRegistryClient::new(&env, &contract_id);
+
+        let attacker = Address::generate(&env);
+        let fake_token = Address::generate(&env);
+
+        client.register_token(
+            &fake_token,
+            &String::from_str(&env, "USDC"),
+            &6u32,
+            &attacker,
+        );
+        assert!(client.is_registered(&fake_token));
+
+        // Admin removes the fake token
+        client.remove_token(&fake_token);
+        assert!(!client.is_registered(&fake_token));
+        assert!(client.get_token(&fake_token).is_none());
+    }
+
+    /// Secure version requires admin approval for registration.
+    #[test]
+    #[should_panic(expected = "not initialized")]
+    fn test_secure_requires_admin_approval() {
+        use crate::secure::SecureTokenRegistryClient;
+
+        let env = Env::default();
+        let contract_id = env.register_contract(None, secure::SecureTokenRegistry);
+        let admin = Address::generate(&env);
+        let random_user = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        // Initialize with admin
+        env.mock_all_auths();
+        SecureTokenRegistryClient::new(&env, &contract_id).initialize(&admin);
+
+        // Clear auths - now require_auth will enforce
+        env.set_auths(&[]);
+
+        // Random user tries to register a token - should panic
+        SecureTokenRegistryClient::new(&env, &contract_id).register_token(
+            &token,
+            &String::from_str(&env, "SCAM"),
+            &18u32,
+        );
+    }
+
+    /// Secure version rejects duplicate symbols.
+    #[test]
+    #[should_panic(expected = "symbol already in use")]
+    fn test_secure_rejects_duplicate_symbols() {
+        use crate::secure::SecureTokenRegistryClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, secure::SecureTokenRegistry);
+        let admin = Address::generate(&env);
+
+        SecureTokenRegistryClient::new(&env, &contract_id).initialize(&admin);
+
+        let token1 = Address::generate(&env);
+        let token2 = Address::generate(&env);
+
+        // Register first token with "USDC"
+        SecureTokenRegistryClient::new(&env, &contract_id).register_token(
+            &token1,
+            &String::from_str(&env, "USDC"),
+            &6u32,
+        );
+
+        // Try to register second token with same symbol - should panic
+        SecureTokenRegistryClient::new(&env, &contract_id).register_token(
+            &token2,
+            &String::from_str(&env, "USDC"),
+            &6u32,
+        );
+    }
+
+    /// Secure version allows admin to register legitimate tokens.
+    #[test]
+    fn test_secure_admin_can_register() {
+        use crate::secure::SecureTokenRegistryClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, secure::SecureTokenRegistry);
+        let admin = Address::generate(&env);
+
+        SecureTokenRegistryClient::new(&env, &contract_id).initialize(&admin);
+
+        let token = Address::generate(&env);
+
+        // Admin registers a legitimate token
+        SecureTokenRegistryClient::new(&env, &contract_id).register_token(
+            &token,
+            &String::from_str(&env, "USDC"),
+            &6u32,
+        );
+
+        let metadata = SecureTokenRegistryClient::new(&env, &contract_id)
+            .get_token(&token)
+            .unwrap();
+        assert_eq!(metadata.symbol, String::from_str(&env, "USDC"));
+        assert_eq!(metadata.decimals, 6);
+        assert_eq!(metadata.registered_by, admin);
+    }
+}

--- a/vulnerable/fake_token_registration/src/secure.rs
+++ b/vulnerable/fake_token_registration/src/secure.rs
@@ -1,0 +1,112 @@
+//! SECURE mirror: Require admin approval for token registration.
+//!
+//! Key fixes:
+//! 1. Only admin can register tokens (prevents arbitrary registration)
+//! 2. Check for duplicate symbols before registration
+//! 3. Optionally verify metadata through token interface (if available)
+//!
+//! This prevents attackers from registering fake tokens with trusted symbols.
+
+use crate::{DataKey, TokenMetadata};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+
+#[contract]
+pub struct SecureTokenRegistry;
+
+#[contractimpl]
+impl SecureTokenRegistry {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// ✅ Fixed: Only admin can register tokens.
+    /// ✅ Fixed: Check for duplicate symbols to prevent confusion.
+    pub fn register_token(
+        env: Env,
+        token_address: Address,
+        symbol: String,
+        decimals: u32,
+    ) {
+        // ✅ Require admin authorization
+        Self::require_admin(&env);
+
+        // ✅ Check if token is already registered
+        if env.storage().persistent().has(&DataKey::Token(token_address.clone())) {
+            panic!("token already registered");
+        }
+
+        // ✅ Check for duplicate symbols
+        if Self::symbol_exists(&env, &symbol) {
+            panic!("symbol already in use");
+        }
+
+        let metadata = TokenMetadata {
+            token_address: token_address.clone(),
+            symbol: symbol.clone(),
+            decimals,
+            registered_by: Self::get_admin(&env),
+            timestamp: env.ledger().timestamp(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(token_address.clone()), &metadata);
+
+        // Store symbol mapping for duplicate check
+        env.storage()
+            .persistent()
+            .set(&DataKey::Symbol(symbol), &token_address);
+    }
+
+    /// Returns the metadata for a registered token, or None if not found.
+    pub fn get_token(env: Env, token_address: Address) -> Option<TokenMetadata> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Token(token_address))
+    }
+
+    /// Returns true if a token is registered.
+    pub fn is_registered(env: Env, token_address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Token(token_address))
+    }
+
+    /// Admin can remove a token from the registry.
+    pub fn remove_token(env: Env, token_address: Address) {
+        Self::require_admin(&env);
+        
+        // Remove symbol mapping
+        if let Some(metadata) = env.storage().persistent().get::<DataKey, TokenMetadata>(&DataKey::Token(token_address.clone())) {
+            env.storage().persistent().remove(&DataKey::Symbol(metadata.symbol));
+        }
+        
+        env.storage().persistent().remove(&DataKey::Token(token_address));
+    }
+
+    /// Check if a symbol is already registered.
+    fn symbol_exists(env: &Env, symbol: &String) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Symbol(symbol.clone()))
+    }
+
+    fn require_admin(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+    }
+
+    fn get_admin(env: &Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+}


### PR DESCRIPTION
closes #259 

## Changes

- **New crate**: `vulnerable/fake_token_registration`
- **Vulnerability**: Attackers can register tokens with trusted symbols (e.g., USDC, XLM) without admin approval or metadata verification
- **Severity**: High
- **Secure implementation**: Includes `src/secure.rs` with admin-only registration and duplicate symbol prevention
- **Comprehensive tests**: Both vulnerable and secure paths are tested

## Vulnerability Details

The vulnerable contract allows anyone to:
1. Register a token with arbitrary metadata (symbol, decimals)
2. Use trusted symbols like 'USDC' for malicious tokens
3. Create multiple tokens with the same symbol

## Secure Fix

The secure implementation:
1. Requires admin authorization for token registration
2. Prevents duplicate symbols
3. Maintains symbol-to-address mapping for validation

## Tests Included

- `test_fake_token_registration_succeeds`: Demonstrates the vulnerability
- `test_duplicate_symbol_allowed`: Shows symbol collision issue
- `test_no_admin_approval_required`: Proves lack of access control
- `test_secure_requires_admin_approval`: Secure version enforces admin auth
- `test_secure_rejects_duplicate_symbols`: Secure version prevents duplicates
- `test_secure_admin_can_register`: Secure version allows legitimate registration
