### PR TITLE
feat: add unwrap without burn vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "vulnerable/mixed_collateral_decimals",
     "vulnerable/signed_unsigned_wrap",
     "vulnerable/abs_min_overflow",
+    "vulnerable/unwrap_without_burn",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/unwrap_without_burn/Cargo.toml
+++ b/vulnerable/unwrap_without_burn/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "unwrap-without-burn"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating unwrap without burning wrapper shares"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/unwrap_without_burn/README.md
+++ b/vulnerable/unwrap_without_burn/README.md
@@ -1,0 +1,161 @@
+# Unwrap Without Burn
+
+## Vulnerability
+
+A wrapper token contract that releases underlying tokens during unwrap but forgets to burn wrapper shares. Users can repeatedly unwrap the same shares and drain the custody contract.
+
+## Severity
+
+**Critical**
+
+## Description
+
+The vulnerable contract implements a token wrapper that allows users to:
+1. **Wrap**: Deposit underlying tokens and receive wrapper shares
+2. **Unwrap**: Redeem wrapper shares for underlying tokens
+
+However, the `unwrap` function has a critical flaw: it transfers underlying tokens to the user but **does not burn or decrement the wrapper token balance**. This allows users to call unwrap multiple times with the same wrapper shares, draining all underlying tokens from custody.
+
+## Vulnerable Code
+
+```rust
+pub fn unwrap(env: Env, user: Address, amount: i128) {
+    user.require_auth();
+
+    // Check user has enough wrapper balance
+    let current_balance: i128 = env
+        .storage()
+        .persistent()
+        .get(&balance_key)
+        .unwrap_or(0);
+
+    if current_balance < amount {
+        panic!("insufficient wrapper balance");
+    }
+
+    // ❌ Transfer underlying tokens WITHOUT burning wrapper shares
+    let token_client = token::TokenClient::new(&env, &underlying_token);
+    token_client.transfer(&env.current_contract_address(), &user, &amount);
+
+    // Update custody balance
+    env.storage()
+        .persistent()
+        .set(&DataKey::CustodyBalance, &(custody - amount));
+
+    // ❌ MISSING: Burn wrapper shares
+    // env.storage().persistent().set(&balance_key, &(current_balance - amount));
+}
+```
+
+## Attack Scenario
+
+1. **Setup**: Attacker deposits 100 underlying tokens, receives 100 wrapper shares
+2. **First unwrap**: Attacker calls `unwrap(100)` → receives 100 underlying tokens
+3. **Wrapper balance unchanged**: Attacker still has 100 wrapper shares (not burned!)
+4. **Refill custody**: Another user deposits tokens, or attacker deposits again
+5. **Second unwrap**: Attacker calls `unwrap(100)` again → receives another 100 underlying tokens
+6. **Repeat**: Continue until custody is completely drained
+
+### Example Attack
+
+```rust
+// Attacker wraps 100 tokens
+wrapper.wrap(&attacker, &100);
+// Balance: 100 wrapper shares, 900 underlying tokens
+
+// First unwrap
+wrapper.unwrap(&attacker, &100);
+// Balance: 100 wrapper shares (BUG!), 1000 underlying tokens
+
+// Refill custody
+wrapper.wrap(&attacker, &100);
+
+// Second unwrap with SAME shares
+wrapper.unwrap(&attacker, &100);
+// Balance: 100 wrapper shares (still!), 1000 underlying tokens
+
+// Attacker has drained 200 tokens using only 100 wrapper shares
+```
+
+## Impact
+
+- **Complete custody drain**: Attackers can extract all underlying tokens
+- **Infinite money glitch**: Same wrapper shares can be reused indefinitely
+- **Loss of funds**: Legitimate users lose their deposited tokens
+- **Protocol insolvency**: Wrapper becomes unbacked and worthless
+
+## Secure Fix
+
+The secure implementation (`src/secure.rs`) fixes this by burning wrapper shares **before** transferring underlying tokens, following the checks-effects-interactions pattern:
+
+```rust
+pub fn unwrap(env: Env, user: Address, amount: i128) {
+    user.require_auth();
+
+    // Checks
+    if current_balance < amount {
+        panic!("insufficient wrapper balance");
+    }
+
+    // ✅ Effects: Burn wrapper shares FIRST
+    env.storage()
+        .persistent()
+        .set(&balance_key, &(current_balance - amount));
+
+    let total_supply: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::TotalSupply)
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalSupply, &(total_supply - amount));
+
+    // Interactions: Transfer underlying tokens AFTER burning
+    let token_client = token::TokenClient::new(&env, &underlying_token);
+    token_client.transfer(&env.current_contract_address(), &user, &amount);
+}
+```
+
+## Key Principles
+
+1. **Checks-Effects-Interactions**: Update state before external calls
+2. **Burn before transfer**: Always decrement balances before releasing assets
+3. **Atomic operations**: Ensure balance updates and transfers are consistent
+4. **Invariant preservation**: Maintain `total_supply == custody_balance` at all times
+
+## Testing
+
+Run the tests to see the vulnerability in action:
+
+```bash
+cargo test -p unwrap-without-burn
+```
+
+Key tests:
+- `test_double_unwrap_succeeds`: Demonstrates unwrapping twice with same shares
+- `test_repeated_unwrap_drains_custody`: Shows custody drainage attack
+- `test_secure_prevents_double_unwrap`: Secure version prevents the attack
+- `test_secure_burns_shares_correctly`: Secure version correctly decrements balances
+
+## Real-World Examples
+
+This vulnerability class has appeared in:
+- **Wrapped token contracts** that forget to burn shares
+- **Vault contracts** that release collateral without updating debt
+- **Staking contracts** that pay rewards without decrementing stake
+- **Bridge contracts** that unlock tokens without burning bridge shares
+
+## Prevention
+
+1. **Always burn/decrement before transfer**: Update balances before releasing assets
+2. **Follow CEI pattern**: Checks → Effects → Interactions
+3. **Test double-spend scenarios**: Verify operations can't be repeated
+4. **Audit state changes**: Ensure all relevant state is updated
+5. **Use reentrancy guards**: Prevent recursive calls (though not the issue here)
+
+## References
+
+- [Checks-Effects-Interactions Pattern](https://docs.soliditylang.org/en/latest/security-considerations.html#use-the-checks-effects-interactions-pattern)
+- [CWE-841: Improper Enforcement of Behavioral Workflow](https://cwe.mitre.org/data/definitions/841.html)
+- [SWC-107: Reentrancy](https://swcregistry.io/docs/SWC-107) (related pattern)

--- a/vulnerable/unwrap_without_burn/src/lib.rs
+++ b/vulnerable/unwrap_without_burn/src/lib.rs
@@ -1,0 +1,369 @@
+//! VULNERABLE: Unwrap Without Burn
+//!
+//! A wrapper token contract that releases underlying tokens during unwrap but
+//! forgets to burn wrapper shares. Users can repeatedly unwrap the same shares
+//! and drain the custody contract.
+//!
+//! VULNERABILITY: The `unwrap` function transfers underlying tokens to the user
+//! but does not decrement or burn the wrapper token balance. This allows users
+//! to call unwrap multiple times with the same wrapper shares.
+//! Severity: Critical
+//!
+//! Attack scenario:
+//! 1. User deposits 100 underlying tokens, receives 100 wrapper shares
+//! 2. User calls unwrap(100) → receives 100 underlying tokens
+//! 3. User still has 100 wrapper shares (not burned!)
+//! 4. User calls unwrap(100) again → receives another 100 underlying tokens
+//! 5. Repeat until custody is drained
+//!
+//! Secure fix: Burn or decrement wrapper shares before transferring underlying tokens.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+
+pub mod secure;
+
+// ── Storage keys ─────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    UnderlyingToken,      // Address of the underlying token
+    WrapperBalance(Address), // Wrapper token balance per user
+    TotalSupply,          // Total wrapper token supply
+    CustodyBalance,       // Amount of underlying tokens held in custody
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct VulnerableWrapper;
+
+#[contractimpl]
+impl VulnerableWrapper {
+    /// Initialize the wrapper with the underlying token address.
+    pub fn initialize(env: Env, underlying_token: Address) {
+        if env.storage().persistent().has(&DataKey::UnderlyingToken) {
+            panic!("already initialized");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::UnderlyingToken, &underlying_token);
+        env.storage().persistent().set(&DataKey::TotalSupply, &0i128);
+        env.storage().persistent().set(&DataKey::CustodyBalance, &0i128);
+    }
+
+    /// Wrap underlying tokens: user deposits underlying, receives wrapper shares.
+    pub fn wrap(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let underlying_token: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UnderlyingToken)
+            .expect("not initialized");
+
+        // Transfer underlying tokens from user to this contract
+        let token_client = token::TokenClient::new(&env, &underlying_token);
+        token_client.transfer(&user, &env.current_contract_address(), &amount);
+
+        // Mint wrapper shares to user
+        let balance_key = DataKey::WrapperBalance(user.clone());
+        let current_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&balance_key)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&balance_key, &(current_balance + amount));
+
+        // Update total supply and custody balance
+        let total_supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalSupply, &(total_supply + amount));
+
+        let custody: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CustodyBalance)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CustodyBalance, &(custody + amount));
+    }
+
+    /// VULNERABLE: Unwrap wrapper tokens to receive underlying tokens.
+    /// ❌ BUG: Transfers underlying tokens but does NOT burn wrapper shares.
+    /// Users can call this repeatedly with the same wrapper balance.
+    pub fn unwrap(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        // Check user has enough wrapper balance
+        let balance_key = DataKey::WrapperBalance(user.clone());
+        let current_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&balance_key)
+            .unwrap_or(0);
+
+        if current_balance < amount {
+            panic!("insufficient wrapper balance");
+        }
+
+        // Check custody has enough underlying tokens
+        let custody: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CustodyBalance)
+            .unwrap_or(0);
+
+        if custody < amount {
+            panic!("insufficient custody balance");
+        }
+
+        let underlying_token: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UnderlyingToken)
+            .expect("not initialized");
+
+        // ❌ BUG: Transfer underlying tokens WITHOUT burning wrapper shares
+        let token_client = token::TokenClient::new(&env, &underlying_token);
+        token_client.transfer(&env.current_contract_address(), &user, &amount);
+
+        // Update custody balance
+        env.storage()
+            .persistent()
+            .set(&DataKey::CustodyBalance, &(custody - amount));
+
+        // ❌ MISSING: Burn wrapper shares
+        // env.storage().persistent().set(&balance_key, &(current_balance - amount));
+        // let total_supply: i128 = env.storage().persistent().get(&DataKey::TotalSupply).unwrap_or(0);
+        // env.storage().persistent().set(&DataKey::TotalSupply, &(total_supply - amount));
+    }
+
+    /// Get wrapper token balance for a user.
+    pub fn balance(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::WrapperBalance(user))
+            .unwrap_or(0)
+    }
+
+    /// Get total wrapper token supply.
+    pub fn total_supply(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0)
+    }
+
+    /// Get custody balance (underlying tokens held by contract).
+    pub fn custody_balance(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CustodyBalance)
+            .unwrap_or(0)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation},
+        Address, Env, IntoVal, Symbol,
+    };
+
+    fn create_token_contract<'a>(env: &Env, admin: &Address) -> (Address, token::TokenClient<'a>) {
+        let contract_id = env.register_stellar_asset_contract(admin.clone());
+        (
+            contract_id.clone(),
+            token::TokenClient::new(env, &contract_id),
+        )
+    }
+
+    fn setup() -> (Env, Address, Address, Address, token::TokenClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        // Create underlying token
+        let (token_id, token_client) = create_token_contract(&env, &admin);
+
+        // Mint underlying tokens to user
+        token_client.mint(&user, &1000);
+
+        // Deploy wrapper contract
+        let wrapper_id = env.register_contract(None, VulnerableWrapper);
+
+        VulnerableWrapperClient::new(&env, &wrapper_id).initialize(&token_id);
+
+        (env, wrapper_id, user, token_id, token_client)
+    }
+
+    /// Demonstrates the vulnerability: user wraps once, unwraps twice with same shares.
+    #[test]
+    fn test_double_unwrap_succeeds() {
+        let (env, wrapper_id, user, _token_id, token_client) = setup();
+        let client = VulnerableWrapperClient::new(&env, &wrapper_id);
+
+        // User wraps 100 tokens
+        client.wrap(&user, &100);
+
+        assert_eq!(client.balance(&user), 100);
+        assert_eq!(client.custody_balance(), 100);
+        assert_eq!(token_client.balance(&user), 900); // 1000 - 100
+
+        // First unwrap: user gets 100 underlying tokens back
+        client.unwrap(&user, &100);
+
+        // ❌ BUG: User still has 100 wrapper shares (not burned!)
+        assert_eq!(client.balance(&user), 100);
+        assert_eq!(client.custody_balance(), 0);
+        assert_eq!(token_client.balance(&user), 1000); // Got 100 back
+
+        // Wrap again to refill custody
+        client.wrap(&user, &100);
+        assert_eq!(client.custody_balance(), 100);
+
+        // Second unwrap with SAME wrapper shares: succeeds again!
+        client.unwrap(&user, &100);
+
+        // User has drained custody twice with same wrapper shares
+        assert_eq!(client.balance(&user), 100); // Still has wrapper shares!
+        assert_eq!(client.custody_balance(), 0);
+        assert_eq!(token_client.balance(&user), 1000); // Got another 100
+    }
+
+    /// Demonstrates repeated unwrapping drains the custody.
+    #[test]
+    fn test_repeated_unwrap_drains_custody() {
+        let (env, wrapper_id, user, _token_id, token_client) = setup();
+        let client = VulnerableWrapperClient::new(&env, &wrapper_id);
+
+        // User wraps 100 tokens
+        client.wrap(&user, &100);
+        assert_eq!(client.balance(&user), 100);
+        assert_eq!(token_client.balance(&user), 900);
+
+        // Unwrap 50 tokens
+        client.unwrap(&user, &50);
+
+        // ❌ User still has 100 wrapper shares (should have 50)
+        assert_eq!(client.balance(&user), 100);
+        assert_eq!(client.custody_balance(), 50);
+        assert_eq!(token_client.balance(&user), 950);
+
+        // Unwrap another 50 with the same wrapper shares
+        client.unwrap(&user, &50);
+
+        // Custody is now empty, but user still has 100 wrapper shares
+        assert_eq!(client.balance(&user), 100);
+        assert_eq!(client.custody_balance(), 0);
+        assert_eq!(token_client.balance(&user), 1000);
+    }
+
+    /// Normal wrap operation works correctly.
+    #[test]
+    fn test_wrap_works() {
+        let (env, wrapper_id, user, _token_id, token_client) = setup();
+        let client = VulnerableWrapperClient::new(&env, &wrapper_id);
+
+        client.wrap(&user, &100);
+
+        assert_eq!(client.balance(&user), 100);
+        assert_eq!(client.total_supply(), 100);
+        assert_eq!(client.custody_balance(), 100);
+        assert_eq!(token_client.balance(&user), 900);
+    }
+
+    /// Secure version burns wrapper shares, preventing double unwrap.
+    #[test]
+    #[should_panic(expected = "insufficient wrapper balance")]
+    fn test_secure_prevents_double_unwrap() {
+        use crate::secure::{SecureWrapper, SecureWrapperClient};
+
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        let (token_id, token_client) = create_token_contract(&env, &admin);
+        token_client.mint(&user, &1000);
+
+        let wrapper_id = env.register_contract(None, SecureWrapper);
+        SecureWrapperClient::new(&env, &wrapper_id).initialize(&token_id);
+
+        let client = SecureWrapperClient::new(&env, &wrapper_id);
+
+        // Wrap 100 tokens
+        client.wrap(&user, &100);
+        assert_eq!(client.balance(&user), 100);
+
+        // First unwrap: burns wrapper shares
+        client.unwrap(&user, &100);
+        assert_eq!(client.balance(&user), 0); // ✅ Shares burned
+
+        // Second unwrap: should panic (insufficient balance)
+        client.unwrap(&user, &100);
+    }
+
+    /// Secure version correctly decrements wrapper balance.
+    #[test]
+    fn test_secure_burns_shares_correctly() {
+        use crate::secure::{SecureWrapper, SecureWrapperClient};
+
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        let (token_id, token_client) = create_token_contract(&env, &admin);
+        token_client.mint(&user, &1000);
+
+        let wrapper_id = env.register_contract(None, SecureWrapper);
+        SecureWrapperClient::new(&env, &wrapper_id).initialize(&token_id);
+
+        let client = SecureWrapperClient::new(&env, &wrapper_id);
+
+        // Wrap 100 tokens
+        client.wrap(&user, &100);
+        assert_eq!(client.balance(&user), 100);
+        assert_eq!(client.total_supply(), 100);
+
+        // Unwrap 60 tokens
+        client.unwrap(&user, &60);
+
+        // ✅ Wrapper balance correctly decremented
+        assert_eq!(client.balance(&user), 40);
+        assert_eq!(client.total_supply(), 40);
+        assert_eq!(client.custody_balance(), 40);
+        assert_eq!(token_client.balance(&user), 960);
+
+        // Can only unwrap remaining 40
+        client.unwrap(&user, &40);
+        assert_eq!(client.balance(&user), 0);
+        assert_eq!(client.total_supply(), 0);
+        assert_eq!(token_client.balance(&user), 1000);
+    }
+}

--- a/vulnerable/unwrap_without_burn/src/secure.rs
+++ b/vulnerable/unwrap_without_burn/src/secure.rs
@@ -1,0 +1,150 @@
+//! SECURE mirror: Burn wrapper shares before transferring underlying tokens.
+//!
+//! Key fix:
+//! - Decrement wrapper balance and total supply BEFORE transferring underlying tokens
+//! - This prevents users from unwrapping the same shares multiple times
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+#[contract]
+pub struct SecureWrapper;
+
+#[contractimpl]
+impl SecureWrapper {
+    pub fn initialize(env: Env, underlying_token: Address) {
+        if env.storage().persistent().has(&DataKey::UnderlyingToken) {
+            panic!("already initialized");
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::UnderlyingToken, &underlying_token);
+        env.storage().persistent().set(&DataKey::TotalSupply, &0i128);
+        env.storage().persistent().set(&DataKey::CustodyBalance, &0i128);
+    }
+
+    pub fn wrap(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let underlying_token: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UnderlyingToken)
+            .expect("not initialized");
+
+        let token_client = token::TokenClient::new(&env, &underlying_token);
+        token_client.transfer(&user, &env.current_contract_address(), &amount);
+
+        let balance_key = DataKey::WrapperBalance(user.clone());
+        let current_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&balance_key)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&balance_key, &(current_balance + amount));
+
+        let total_supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalSupply, &(total_supply + amount));
+
+        let custody: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CustodyBalance)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CustodyBalance, &(custody + amount));
+    }
+
+    /// ✅ Fixed: Burns wrapper shares BEFORE transferring underlying tokens.
+    pub fn unwrap(env: Env, user: Address, amount: i128) {
+        user.require_auth();
+
+        if amount <= 0 {
+            panic!("amount must be positive");
+        }
+
+        let balance_key = DataKey::WrapperBalance(user.clone());
+        let current_balance: i128 = env
+            .storage()
+            .persistent()
+            .get(&balance_key)
+            .unwrap_or(0);
+
+        if current_balance < amount {
+            panic!("insufficient wrapper balance");
+        }
+
+        let custody: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CustodyBalance)
+            .unwrap_or(0);
+
+        if custody < amount {
+            panic!("insufficient custody balance");
+        }
+
+        // ✅ Burn wrapper shares FIRST (checks-effects-interactions pattern)
+        env.storage()
+            .persistent()
+            .set(&balance_key, &(current_balance - amount));
+
+        let total_supply: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TotalSupply, &(total_supply - amount));
+
+        // Update custody balance
+        env.storage()
+            .persistent()
+            .set(&DataKey::CustodyBalance, &(custody - amount));
+
+        // Transfer underlying tokens AFTER burning shares
+        let underlying_token: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UnderlyingToken)
+            .expect("not initialized");
+
+        let token_client = token::TokenClient::new(&env, &underlying_token);
+        token_client.transfer(&env.current_contract_address(), &user, &amount);
+    }
+
+    pub fn balance(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::WrapperBalance(user))
+            .unwrap_or(0)
+    }
+
+    pub fn total_supply(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0)
+    }
+
+    pub fn custody_balance(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CustodyBalance)
+            .unwrap_or(0)
+    }
+}


### PR DESCRIPTION
closes #260 



The Vulnerability (Critical Severity)
Wrapper token releases underlying tokens during unwrap
Forgets to burn wrapper shares
Users can repeatedly unwrap the same shares to drain all custody funds
"Infinite money glitch" - same shares reused indefinitely
Attack Flow
1. Wrap 100 tokens → get 100 shares
2. Unwrap 100 shares → get 100 tokens (shares NOT burned!)
3. Unwrap 100 shares AGAIN → get another 100 tokens
4. Repeat until custody is empty
The Fix
Burn wrapper shares before transferring underlying tokens
Follows checks-effects-interactions pattern
Prevents double-spending of wrapper shares
Deliverables
Vulnerable implementation (
lib.rs
) - Demonstrates the critical flaw
Secure implementation (
secure.rs
) - Shows proper share burning
5 comprehensive tests - Cover attack scenarios and secure prevention
Documentation (README.md) - Attack details, impact, and mitigation
