### PR TITLE
Add four new Soroban vulnerability fixtures for scanner training, each with a vulnerable `lib.rs`, fixed `secure.rs`, and tests for all three required scenarios

### DIFF
--- a/vulnerable/airdrop_campaign_collision/Cargo.toml
+++ b/vulnerable/airdrop_campaign_collision/Cargo.toml
@@ -1,0 +1,15 @@
+[workspace]
+
+[package]
+name = "airdrop-campaign-collision"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban airdrop that keys claimed storage only by claimant address"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/vulnerable/airdrop_campaign_collision/src/lib.rs
+++ b/vulnerable/airdrop_campaign_collision/src/lib.rs
@@ -1,0 +1,218 @@
+//! VULNERABLE: Airdrop Campaign ID Omitted from Claim Tracking
+//!
+//! A multi-campaign airdrop that keys claimed storage only by claimant address,
+//! so claiming campaign A marks campaign B as claimed for the same address.
+//!
+//! VULNERABILITY: storage key is `(claimant_address,)` only.
+//!
+//! SECURE MIRROR: `secure::SecureAirdrop` keys claims by `(campaign_id, claimant)`.
+
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env,
+    Vec,
+};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    CampaignRoot(u32),
+    Claimed(Address),
+}
+
+pub fn leaf_hash(env: &Env, claimant: &Address, amount: i128) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.append(&claimant.to_xdr(env));
+    data.extend_from_array(&amount.to_be_bytes());
+    env.crypto().sha256(&data).into()
+}
+
+pub fn hash_pair(env: &Env, a: &BytesN<32>, b: &BytesN<32>) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    if a <= b {
+        data.append(&Bytes::from(a.clone()));
+        data.append(&Bytes::from(b.clone()));
+    } else {
+        data.append(&Bytes::from(b.clone()));
+        data.append(&Bytes::from(a.clone()));
+    }
+    env.crypto().sha256(&data).into()
+}
+
+pub fn verify_merkle_proof(
+    env: &Env,
+    claimant: &Address,
+    amount: i128,
+    proof: &Vec<BytesN<32>>,
+    root: &BytesN<32>,
+) {
+    let mut node = leaf_hash(env, claimant, amount);
+    for sibling in proof.iter() {
+        node = hash_pair(env, &node, &sibling);
+    }
+    assert!(node == *root, "invalid merkle proof");
+}
+
+#[contract]
+pub struct VulnerableAirdrop;
+
+#[contractimpl]
+impl VulnerableAirdrop {
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn create_campaign(env: Env, campaign_id: u32, merkle_root: BytesN<32>) {
+        Self::require_admin_auth(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignRoot(campaign_id), &merkle_root);
+    }
+
+    /// VULNERABLE: claimed flag is keyed only by claimant, not campaign.
+    pub fn claim(
+        env: Env,
+        campaign_id: u32,
+        claimant: Address,
+        amount: i128,
+        proof: Vec<BytesN<32>>,
+    ) {
+        claimant.require_auth();
+        // ❌ Missing campaign_id in storage key — cross-campaign collision.
+        let claimed_key = DataKey::Claimed(claimant.clone());
+        assert!(
+            !env.storage()
+                .persistent()
+                .get(&claimed_key)
+                .unwrap_or(false),
+            "already claimed"
+        );
+
+        let root: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CampaignRoot(campaign_id))
+            .expect("campaign not found");
+        verify_merkle_proof(&env, &claimant, amount, &proof, &root);
+
+        env.storage().persistent().set(&claimed_key, &true);
+        env.events().publish(
+            (symbol_short!("claim"), campaign_id),
+            (claimant, amount),
+        );
+    }
+
+    pub fn is_claimed(env: Env, claimant: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Claimed(claimant))
+            .unwrap_or(false)
+    }
+
+    fn require_admin_auth(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    fn build_tree(
+        env: &Env,
+        claimant: &Address,
+        amount: i128,
+        other: &Address,
+    ) -> (BytesN<32>, Vec<BytesN<32>>) {
+        let leaf0 = leaf_hash(env, claimant, amount);
+        let leaf1 = leaf_hash(env, other, 0i128);
+        let root = hash_pair(env, &leaf0, &leaf1);
+        let mut proof = Vec::new(env);
+        proof.push_back(leaf1);
+        (root, proof)
+    }
+
+    fn setup_campaigns(
+        env: &Env,
+        client: &VulnerableAirdropClient,
+        admin: &Address,
+        claimant: &Address,
+    ) -> (Vec<BytesN<32>>, Vec<BytesN<32>>) {
+        let other_a = Address::generate(env);
+        let other_b = Address::generate(env);
+        let (root_a, proof_a) = build_tree(env, claimant, 500, &other_a);
+        let (root_b, proof_b) = build_tree(env, claimant, 700, &other_b);
+        client.initialize(admin);
+        client.create_campaign(&1, &root_a);
+        client.create_campaign(&2, &root_b);
+        (proof_a, proof_b)
+    }
+
+    #[test]
+    fn test_claiming_campaign_a_blocks_campaign_b() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, VulnerableAirdrop);
+        let client = VulnerableAirdropClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let claimant = Address::generate(&env);
+        let (proof_a, proof_b) = setup_campaigns(&env, &client, &admin, &claimant);
+
+        client.claim(&1, &claimant, &500, &proof_a);
+        assert!(client.is_claimed(&claimant));
+
+        let second = client.try_claim(&2, &claimant, &700, &proof_b);
+        assert!(second.is_err(), "campaign B blocked by shared claimed state");
+    }
+
+    #[test]
+    fn test_campaigns_share_claimed_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, VulnerableAirdrop);
+        let client = VulnerableAirdropClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let claimant = Address::generate(&env);
+        let (proof_a, _proof_b) = setup_campaigns(&env, &client, &admin, &claimant);
+
+        assert!(!client.is_claimed(&claimant));
+        client.claim(&1, &claimant, &500, &proof_a);
+        assert!(
+            client.is_claimed(&claimant),
+            "single claimed flag shared across campaigns"
+        );
+    }
+
+    #[test]
+    fn test_secure_campaigns_isolated() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureAirdrop);
+        let client = secure::SecureAirdropClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let claimant = Address::generate(&env);
+
+        let other_a = Address::generate(&env);
+        let other_b = Address::generate(&env);
+        let (root_a, proof_a) = secure::build_tree(&env, 1, &claimant, 500, &other_a);
+        let (root_b, proof_b) = secure::build_tree(&env, 2, &claimant, 700, &other_b);
+
+        client.initialize(&admin);
+        client.create_campaign(&1, &root_a);
+        client.create_campaign(&2, &root_b);
+
+        client.claim(&1, &claimant, &500, &proof_a);
+        client.claim(&2, &claimant, &700, &proof_b);
+        assert!(client.is_claimed(&1, &claimant));
+        assert!(client.is_claimed(&2, &claimant));
+    }
+}

--- a/vulnerable/airdrop_campaign_collision/src/secure.rs
+++ b/vulnerable/airdrop_campaign_collision/src/secure.rs
@@ -1,0 +1,122 @@
+//! SECURE: Airdrop Campaign ID Included in Claim Tracking
+//!
+//! Keys claimed storage by `(campaign_id, claimant)` and includes campaign ID
+//! in Merkle proof leaves.
+
+use super::{hash_pair, DataKey};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env,
+    Vec,
+};
+
+#[contracttype]
+pub struct ClaimKey(pub u32, pub Address);
+
+pub fn leaf_hash(
+    env: &Env,
+    campaign_id: u32,
+    claimant: &Address,
+    amount: i128,
+) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    data.extend_from_array(&campaign_id.to_be_bytes());
+    data.append(&claimant.to_xdr(env));
+    data.extend_from_array(&amount.to_be_bytes());
+    env.crypto().sha256(&data).into()
+}
+
+pub fn build_tree(
+    env: &Env,
+    campaign_id: u32,
+    claimant: &Address,
+    amount: i128,
+    other: &soroban_sdk::Address,
+) -> (BytesN<32>, Vec<BytesN<32>>) {
+    let leaf0 = leaf_hash(env, campaign_id, claimant, amount);
+    let leaf1 = leaf_hash(env, campaign_id, other, 0i128);
+    let root = hash_pair(env, &leaf0, &leaf1);
+    let mut proof = Vec::new(env);
+    proof.push_back(leaf1);
+    (root, proof)
+}
+
+#[contract]
+pub struct SecureAirdrop;
+
+#[contractimpl]
+impl SecureAirdrop {
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn create_campaign(env: Env, campaign_id: u32, merkle_root: BytesN<32>) {
+        Self::require_admin_auth(&env);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignRoot(campaign_id), &merkle_root);
+    }
+
+    /// ✅ Claimed flag is scoped to campaign and leaf hash includes campaign ID.
+    pub fn claim(
+        env: Env,
+        campaign_id: u32,
+        claimant: Address,
+        amount: i128,
+        proof: Vec<BytesN<32>>,
+    ) {
+        claimant.require_auth();
+        let claimed_key = ClaimKey(campaign_id, claimant.clone());
+        assert!(
+            !env.storage()
+                .persistent()
+                .get(&claimed_key)
+                .unwrap_or(false),
+            "already claimed"
+        );
+
+        let root: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CampaignRoot(campaign_id))
+            .expect("campaign not found");
+        verify_merkle_proof_secure(&env, campaign_id, &claimant, amount, &proof, &root);
+
+        env.storage().persistent().set(&claimed_key, &true);
+        env.events().publish(
+            (symbol_short!("claim"), campaign_id),
+            (claimant, amount),
+        );
+    }
+
+    pub fn is_claimed(env: Env, campaign_id: u32, claimant: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&ClaimKey(campaign_id, claimant))
+            .unwrap_or(false)
+    }
+
+    fn require_admin_auth(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}
+
+fn verify_merkle_proof_secure(
+    env: &Env,
+    campaign_id: u32,
+    claimant: &Address,
+    amount: i128,
+    proof: &Vec<BytesN<32>>,
+    root: &BytesN<32>,
+) {
+    let mut node = leaf_hash(env, campaign_id, claimant, amount);
+    for sibling in proof.iter() {
+        node = hash_pair(env, &node, &sibling);
+    }
+    assert!(node == *root, "invalid merkle proof");
+}

--- a/vulnerable/merkle_duplicate_siblings/Cargo.toml
+++ b/vulnerable/merkle_duplicate_siblings/Cargo.toml
@@ -1,0 +1,15 @@
+[workspace]
+
+[package]
+name = "merkle-duplicate-siblings"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban Merkle verifier that accepts malformed proofs with duplicate siblings"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/vulnerable/merkle_duplicate_siblings/src/lib.rs
+++ b/vulnerable/merkle_duplicate_siblings/src/lib.rs
@@ -1,0 +1,147 @@
+//! VULNERABLE: Merkle Proof Accepts Duplicate Sibling Nodes
+//!
+//! A Merkle verifier that folds sibling lists without validating proof shape,
+//! allowing malformed proofs with repeated siblings to verify.
+//!
+//! VULNERABILITY: no depth check, no duplicate detection, no length enforcement.
+//!
+//! SECURE MIRROR: `secure::SecureMerkleVerifier` stores expected tree depth,
+//! rejects proofs whose length does not match, and rejects duplicate siblings.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Bytes, BytesN, Env, Vec};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Root,
+}
+
+pub fn hash_pair(env: &Env, a: &BytesN<32>, b: &BytesN<32>) -> BytesN<32> {
+    let mut data = Bytes::new(env);
+    if a <= b {
+        data.append(&Bytes::from(a.clone()));
+        data.append(&Bytes::from(b.clone()));
+    } else {
+        data.append(&Bytes::from(b.clone()));
+        data.append(&Bytes::from(a.clone()));
+    }
+    env.crypto().sha256(&data).into()
+}
+
+pub fn fold_proof(env: &Env, leaf: &BytesN<32>, proof: &Vec<BytesN<32>>) -> BytesN<32> {
+    let mut node = leaf.clone();
+    for sibling in proof.iter() {
+        node = hash_pair(env, &node, &sibling);
+    }
+    node
+}
+
+#[contract]
+pub struct VulnerableMerkleVerifier;
+
+#[contractimpl]
+impl VulnerableMerkleVerifier {
+    pub fn initialize(env: Env, root: BytesN<32>) {
+        env.storage().persistent().set(&DataKey::Root, &root);
+    }
+
+    /// VULNERABLE: folds siblings with no depth or duplicate validation.
+    pub fn verify(env: Env, leaf: BytesN<32>, proof: Vec<BytesN<32>>) -> bool {
+        let root: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Root)
+            .expect("not initialized");
+        // ❌ Missing: proof length check, duplicate sibling detection.
+        fold_proof(&env, &leaf, &proof) == root
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{BytesN, Env, Vec};
+
+    fn leaf(env: &Env, byte: u8) -> BytesN<32> {
+        BytesN::from_array(env, &[byte; 32])
+    }
+
+    fn build_depth_two_tree(env: &Env) -> (BytesN<32>, BytesN<32>, Vec<BytesN<32>>) {
+        let leaf_a = leaf(env, 0x01);
+        let leaf_b = leaf(env, 0x02);
+        let leaf_c = leaf(env, 0x03);
+        let leaf_d = leaf(env, 0x04);
+
+        let level1_left = hash_pair(env, &leaf_a, &leaf_b);
+        let level1_right = hash_pair(env, &leaf_c, &leaf_d);
+        let root = hash_pair(env, &level1_left, &level1_right);
+
+        let mut proof = Vec::new(env);
+        proof.push_back(leaf_b.clone());
+        proof.push_back(level1_right.clone());
+
+        (root, leaf_a, proof)
+    }
+
+    #[test]
+    fn test_well_formed_proof_accepted() {
+        let env = Env::default();
+        let id = env.register_contract(None, VulnerableMerkleVerifier);
+        let client = VulnerableMerkleVerifierClient::new(&env, &id);
+        let (root, leaf_a, proof) = build_depth_two_tree(&env);
+        client.initialize(&root);
+        assert!(client.verify(&leaf_a, &proof));
+    }
+
+    #[test]
+    fn test_duplicate_sibling_proof_accepted() {
+        let env = Env::default();
+        let id = env.register_contract(None, VulnerableMerkleVerifier);
+        let client = VulnerableMerkleVerifierClient::new(&env, &id);
+        let leaf_a = leaf(&env, 0x01);
+        let sibling = leaf(&env, 0x02);
+        let once = hash_pair(&env, &leaf_a, &sibling);
+        let root = hash_pair(&env, &once, &sibling);
+
+        let mut proof = Vec::new(&env);
+        proof.push_back(sibling.clone());
+        proof.push_back(sibling);
+
+        client.initialize(&root);
+        assert!(
+            client.verify(&leaf_a, &proof),
+            "vulnerable path accepts proof with repeated sibling"
+        );
+    }
+
+    #[test]
+    fn test_secure_well_formed_proof_accepted() {
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureMerkleVerifier);
+        let client = secure::SecureMerkleVerifierClient::new(&env, &id);
+        let (root, leaf_a, proof) = build_depth_two_tree(&env);
+        client.initialize(&root, &2u32);
+        assert!(client.verify(&leaf_a, &proof));
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate sibling")]
+    fn test_secure_rejects_duplicate_sibling_proof() {
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureMerkleVerifier);
+        let client = secure::SecureMerkleVerifierClient::new(&env, &id);
+        let leaf_a = leaf(&env, 0x01);
+        let sibling = leaf(&env, 0x02);
+        let once = hash_pair(&env, &leaf_a, &sibling);
+        let root = hash_pair(&env, &once, &sibling);
+
+        let mut proof = Vec::new(&env);
+        proof.push_back(sibling.clone());
+        proof.push_back(sibling);
+
+        client.initialize(&root, &2u32);
+        client.verify(&leaf_a, &proof);
+    }
+}

--- a/vulnerable/merkle_duplicate_siblings/src/secure.rs
+++ b/vulnerable/merkle_duplicate_siblings/src/secure.rs
@@ -1,0 +1,55 @@
+//! SECURE: Merkle Proof Validates Depth and Rejects Duplicate Siblings
+//!
+//! Stores expected tree depth at initialisation and rejects malformed proofs.
+
+use super::fold_proof;
+use soroban_sdk::{contract, contractimpl, contracttype, BytesN, Env, Vec};
+
+#[contracttype]
+pub enum SecureDataKey {
+    Root,
+    Depth,
+}
+
+#[contract]
+pub struct SecureMerkleVerifier;
+
+#[contractimpl]
+impl SecureMerkleVerifier {
+    pub fn initialize(env: Env, root: BytesN<32>, depth: u32) {
+        env.storage().persistent().set(&SecureDataKey::Root, &root);
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::Depth, &depth);
+    }
+
+    /// ✅ Enforces proof length and rejects duplicate sibling nodes.
+    pub fn verify(env: Env, leaf: BytesN<32>, proof: Vec<BytesN<32>>) -> bool {
+        let root: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::Root)
+            .expect("not initialized");
+        let depth: u32 = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::Depth)
+            .expect("depth not set");
+
+        if proof.len() as u32 != depth {
+            panic!("invalid proof length");
+        }
+
+        let mut seen = Vec::new(&env);
+        for sibling in proof.iter() {
+            for prior in seen.iter() {
+                if prior == sibling {
+                    panic!("duplicate sibling");
+                }
+            }
+            seen.push_back(sibling.clone());
+        }
+
+        fold_proof(&env, &leaf, &proof) == root
+    }
+}

--- a/vulnerable/revoked_vesting_claim/Cargo.toml
+++ b/vulnerable/revoked_vesting_claim/Cargo.toml
@@ -1,0 +1,15 @@
+[workspace]
+
+[package]
+name = "revoked-vesting-claim"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban vesting contract that allows claims after revocation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/vulnerable/revoked_vesting_claim/src/lib.rs
+++ b/vulnerable/revoked_vesting_claim/src/lib.rs
@@ -1,0 +1,192 @@
+//! VULNERABLE: Revoked Vesting Schedule Can Still Be Claimed
+//!
+//! A vesting contract where `claim` ignores the stored revocation flag and
+//! pays out tokens even after an admin revokes the schedule.
+//!
+//! VULNERABILITY: `claim()` reads the schedule but performs no revocation check.
+//!
+//! SECURE MIRROR: `secure::SecureVesting` rejects claims when `revoked == true`.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[derive(Clone)]
+#[contracttype]
+pub struct VestingSchedule {
+    pub total: i128,
+    pub claimed: i128,
+    pub cliff_ledger: u32,
+    pub end_ledger: u32,
+    pub revoked: bool,
+    pub revoked_at: Option<u32>,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Schedule(Address),
+}
+
+pub fn vested_for_schedule(env: &Env, schedule: &VestingSchedule) -> i128 {
+    let now = env.ledger().sequence();
+    let effective_now = match schedule.revoked_at {
+        Some(revoked_at) if now > revoked_at => revoked_at,
+        _ => now,
+    };
+
+    if effective_now < schedule.cliff_ledger {
+        return 0;
+    }
+    if effective_now >= schedule.end_ledger {
+        return schedule.total;
+    }
+    let elapsed = (effective_now - schedule.cliff_ledger) as i128;
+    let duration = (schedule.end_ledger - schedule.cliff_ledger) as i128;
+    schedule.total * elapsed / duration
+}
+
+#[contract]
+pub struct VulnerableVesting;
+
+#[contractimpl]
+impl VulnerableVesting {
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn create_schedule(
+        env: Env,
+        beneficiary: Address,
+        total: i128,
+        cliff_ledger: u32,
+        end_ledger: u32,
+    ) {
+        Self::require_admin_auth(&env);
+        let key = DataKey::Schedule(beneficiary.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("schedule already exists");
+        }
+        let schedule = VestingSchedule {
+            total,
+            claimed: 0,
+            cliff_ledger,
+            end_ledger,
+            revoked: false,
+            revoked_at: None,
+        };
+        env.storage().persistent().set(&key, &schedule);
+    }
+
+    pub fn revoke(env: Env, beneficiary: Address) {
+        Self::require_admin_auth(&env);
+        let key = DataKey::Schedule(beneficiary);
+        let mut schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("schedule not found");
+        if schedule.revoked {
+            panic!("already revoked");
+        }
+        schedule.revoked = true;
+        schedule.revoked_at = Some(env.ledger().sequence());
+        env.storage().persistent().set(&key, &schedule);
+    }
+
+    /// VULNERABLE: no revocation check before paying out vested tokens.
+    pub fn claim(env: Env, beneficiary: Address) -> i128 {
+        beneficiary.require_auth();
+        let key = DataKey::Schedule(beneficiary);
+        let schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("schedule not found");
+
+        // ❌ Missing: if schedule.revoked { panic!("schedule revoked"); }
+        let vested = vested_for_schedule(&env, &schedule);
+        if vested <= schedule.claimed {
+            return 0;
+        }
+        vested - schedule.claimed
+    }
+
+    pub fn is_revoked(env: Env, beneficiary: Address) -> bool {
+        let schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(beneficiary))
+            .expect("schedule not found");
+        schedule.revoked
+    }
+
+    fn require_admin_auth(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env};
+
+    fn setup() -> (Env, VulnerableVestingClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, VulnerableVesting);
+        let client = VulnerableVestingClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        client.initialize(&admin);
+        client.create_schedule(&beneficiary, &1_000, &200, &400);
+        (env, client, admin, beneficiary)
+    }
+
+    #[test]
+    fn test_revoked_schedule_still_claimable_after_advancing_ledgers() {
+        let (env, client, _admin, beneficiary) = setup();
+        env.ledger().set_sequence_number(250);
+        client.revoke(&beneficiary);
+        assert!(client.is_revoked(&beneficiary));
+
+        env.ledger().set_sequence_number(350);
+        let payout = client.claim(&beneficiary);
+        assert!(payout > 0, "vulnerable path still pays after revocation");
+    }
+
+    #[test]
+    fn test_claim_at_exact_revocation_ledger_allowed() {
+        let (env, client, _admin, beneficiary) = setup();
+        env.ledger().set_sequence_number(250);
+        client.revoke(&beneficiary);
+
+        let payout = client.claim(&beneficiary);
+        assert!(payout > 0, "vulnerable path allows claim at revocation ledger");
+    }
+
+    #[test]
+    #[should_panic(expected = "schedule revoked")]
+    fn test_secure_rejects_claim_after_revocation() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureVesting);
+        let client = secure::SecureVestingClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        client.initialize(&admin);
+        client.create_schedule(&beneficiary, &1_000, &200, &400);
+
+        env.ledger().set_sequence_number(250);
+        client.revoke(&beneficiary);
+        env.ledger().set_sequence_number(350);
+        client.claim(&beneficiary);
+    }
+}

--- a/vulnerable/revoked_vesting_claim/src/secure.rs
+++ b/vulnerable/revoked_vesting_claim/src/secure.rs
@@ -1,0 +1,98 @@
+//! SECURE: Revoked Vesting Schedule Cannot Be Claimed
+//!
+//! Rejects claims when the schedule has been revoked.
+
+use super::{vested_for_schedule, DataKey, VestingSchedule};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureVesting;
+
+#[contractimpl]
+impl SecureVesting {
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn create_schedule(
+        env: Env,
+        beneficiary: Address,
+        total: i128,
+        cliff_ledger: u32,
+        end_ledger: u32,
+    ) {
+        Self::require_admin_auth(&env);
+        let key = DataKey::Schedule(beneficiary.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("schedule already exists");
+        }
+        let schedule = VestingSchedule {
+            total,
+            claimed: 0,
+            cliff_ledger,
+            end_ledger,
+            revoked: false,
+            revoked_at: None,
+        };
+        env.storage().persistent().set(&key, &schedule);
+    }
+
+    pub fn revoke(env: Env, beneficiary: Address) {
+        Self::require_admin_auth(&env);
+        let key = DataKey::Schedule(beneficiary);
+        let mut schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("schedule not found");
+        if schedule.revoked {
+            panic!("already revoked");
+        }
+        schedule.revoked = true;
+        schedule.revoked_at = Some(env.ledger().sequence());
+        env.storage().persistent().set(&key, &schedule);
+    }
+
+    /// ✅ Rejects claims on revoked schedules.
+    pub fn claim(env: Env, beneficiary: Address) -> i128 {
+        beneficiary.require_auth();
+        let key = DataKey::Schedule(beneficiary);
+        let mut schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("schedule not found");
+
+        if schedule.revoked {
+            panic!("schedule revoked");
+        }
+
+        let vested = vested_for_schedule(&env, &schedule);
+        if vested <= schedule.claimed {
+            return 0;
+        }
+        let claimable = vested - schedule.claimed;
+        schedule.claimed = vested;
+        env.storage().persistent().set(&key, &schedule);
+        claimable
+    }
+
+    pub fn is_revoked(env: Env, beneficiary: Address) -> bool {
+        let schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(beneficiary))
+            .expect("schedule not found");
+        schedule.revoked
+    }
+
+    fn require_admin_auth(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}

--- a/vulnerable/vesting_claimed_not_subtracted/Cargo.toml
+++ b/vulnerable/vesting_claimed_not_subtracted/Cargo.toml
@@ -1,0 +1,15 @@
+[workspace]
+
+[package]
+name = "vesting-claimed-not-subtracted"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban vesting contract that pays full vested amount on every claim"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "21.0.0", features = ["testutils"] }

--- a/vulnerable/vesting_claimed_not_subtracted/src/lib.rs
+++ b/vulnerable/vesting_claimed_not_subtracted/src/lib.rs
@@ -1,0 +1,160 @@
+//! VULNERABLE: Vesting Claim Does Not Subtract Previously Claimed Amount
+//!
+//! A vesting contract where `claim` transfers the full vested amount every time,
+//! ignoring how much has already been claimed. Repeated claims drain the vault.
+//!
+//! VULNERABILITY: `claimable = vested` with no subtraction of `schedule.claimed`
+//! and no update to the claimed record after payout.
+//!
+//! SECURE MIRROR: `secure::SecureVesting` computes `claimable = vested - claimed`
+//! and updates `claimed` before returning the payout.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[derive(Clone)]
+#[contracttype]
+pub struct VestingSchedule {
+    pub total: i128,
+    pub claimed: i128,
+    pub cliff_ledger: u32,
+    pub end_ledger: u32,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Schedule(Address),
+}
+
+pub fn vested_for_schedule(env: &Env, schedule: &VestingSchedule) -> i128 {
+    let now = env.ledger().sequence();
+    if now < schedule.cliff_ledger {
+        return 0;
+    }
+    if now >= schedule.end_ledger {
+        return schedule.total;
+    }
+    let elapsed = (now - schedule.cliff_ledger) as i128;
+    let duration = (schedule.end_ledger - schedule.cliff_ledger) as i128;
+    schedule.total * elapsed / duration
+}
+
+#[contract]
+pub struct VulnerableVesting;
+
+#[contractimpl]
+impl VulnerableVesting {
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn create_schedule(
+        env: Env,
+        beneficiary: Address,
+        total: i128,
+        cliff_ledger: u32,
+        end_ledger: u32,
+    ) {
+        Self::require_admin_auth(&env);
+        let key = DataKey::Schedule(beneficiary.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("schedule already exists");
+        }
+        let schedule = VestingSchedule {
+            total,
+            claimed: 0,
+            cliff_ledger,
+            end_ledger,
+        };
+        env.storage().persistent().set(&key, &schedule);
+    }
+
+    /// VULNERABLE: pays the full vested amount on every call without subtracting
+    /// previously claimed tokens or updating the claimed record.
+    pub fn claim(env: Env, beneficiary: Address) -> i128 {
+        beneficiary.require_auth();
+        let key = DataKey::Schedule(beneficiary);
+        let schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("schedule not found");
+
+        let vested = vested_for_schedule(&env, &schedule);
+        // ❌ Missing: claimable = vested - schedule.claimed; update claimed record.
+        vested
+    }
+
+    pub fn claimed_amount(env: Env, beneficiary: Address) -> i128 {
+        let schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(beneficiary))
+            .expect("schedule not found");
+        schedule.claimed
+    }
+
+    fn require_admin_auth(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env};
+
+    fn setup() -> (Env, VulnerableVestingClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, VulnerableVesting);
+        let client = VulnerableVestingClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        client.initialize(&admin);
+        client.create_schedule(&beneficiary, &1_000, &200, &400);
+        env.ledger().set_sequence_number(300);
+        (env, client, admin, beneficiary)
+    }
+
+    #[test]
+    fn test_claim_once_after_cliff_succeeds() {
+        let (_env, client, _admin, beneficiary) = setup();
+        assert_eq!(client.claim(&beneficiary), 500);
+    }
+
+    #[test]
+    fn test_second_claim_pays_full_vested_again() {
+        let (_env, client, _admin, beneficiary) = setup();
+        let first = client.claim(&beneficiary);
+        let second = client.claim(&beneficiary);
+        assert_eq!(first, 500);
+        assert_eq!(second, 500, "vulnerable path pays full vested amount again");
+    }
+
+    #[test]
+    #[should_panic(expected = "nothing claimable")]
+    fn test_secure_second_claim_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureVesting);
+        let client = secure::SecureVestingClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        client.initialize(&admin);
+        client.create_schedule(&beneficiary, &1_000, &200, &400);
+        env.ledger().set_sequence_number(300);
+
+        assert_eq!(client.claim(&beneficiary), 500);
+        client.claim(&beneficiary);
+    }
+}

--- a/vulnerable/vesting_claimed_not_subtracted/src/secure.rs
+++ b/vulnerable/vesting_claimed_not_subtracted/src/secure.rs
@@ -1,0 +1,78 @@
+//! SECURE: Vesting Claim Subtracts Previously Claimed Amount
+//!
+//! Computes `claimable = vested - claimed` and updates the claimed record
+//! before returning the payout.
+
+use super::{vested_for_schedule, DataKey, VestingSchedule};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureVesting;
+
+#[contractimpl]
+impl SecureVesting {
+    pub fn initialize(env: Env, admin: Address) {
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn create_schedule(
+        env: Env,
+        beneficiary: Address,
+        total: i128,
+        cliff_ledger: u32,
+        end_ledger: u32,
+    ) {
+        Self::require_admin_auth(&env);
+        let key = DataKey::Schedule(beneficiary.clone());
+        if env.storage().persistent().has(&key) {
+            panic!("schedule already exists");
+        }
+        let schedule = VestingSchedule {
+            total,
+            claimed: 0,
+            cliff_ledger,
+            end_ledger,
+        };
+        env.storage().persistent().set(&key, &schedule);
+    }
+
+    /// ✅ Subtracts previously claimed amount and records the new claimed total.
+    pub fn claim(env: Env, beneficiary: Address) -> i128 {
+        beneficiary.require_auth();
+        let key = DataKey::Schedule(beneficiary);
+        let mut schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("schedule not found");
+
+        let vested = vested_for_schedule(&env, &schedule);
+        if vested <= schedule.claimed {
+            panic!("nothing claimable");
+        }
+
+        let claimable = vested - schedule.claimed;
+        schedule.claimed = vested;
+        env.storage().persistent().set(&key, &schedule);
+        claimable
+    }
+
+    pub fn claimed_amount(env: Env, beneficiary: Address) -> i128 {
+        let schedule: VestingSchedule = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Schedule(beneficiary))
+            .expect("schedule not found");
+        schedule.claimed
+    }
+
+    fn require_admin_auth(env: &Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("contract not initialized");
+        admin.require_auth();
+    }
+}


### PR DESCRIPTION
## Summary
- Add four new Soroban vulnerability fixtures for scanner training, each with a vulnerable `lib.rs`, fixed `secure.rs`, and tests for all three required scenarios.
- **`vesting_claimed_not_subtracted`** (Critical): `claim` pays the full vested amount every time without subtracting prior claims.
- **`revoked_vesting_claim`** (High): `claim` ignores the revoked flag and still pays out after revocation.
- **`airdrop_campaign_collision`** (High): claimed storage is keyed only by claimant address, causing cross-campaign collision.
- **`merkle_duplicate_siblings`** (Medium): Merkle verifier folds sibling lists without depth, length, or duplicate checks.

Each crate is self-contained with its own workspace table and can be tested via `cargo test` inside the crate directory.

## Test plan
- [x] `cd vulnerable/vesting_claimed_not_subtracted && cargo test`
- [x] `cd vulnerable/revoked_vesting_claim && cargo test`
- [x] `cd vulnerable/airdrop_campaign_collision && cargo test`
- [x] `cd vulnerable/merkle_duplicate_siblings && cargo test`
- [x] Confirm each crate has `src/lib.rs`, `src/secure.rs`, and tests covering vulnerable exploit + secure rejection paths
closes #277
closes #278 
closes #282 
closes #283