### PR TITLE
feat(vuln): add scan_result_overwrite vulnerable contract fixture

### DIFF
--- a/vulnerable/scan_result_overwrite/Cargo.toml
+++ b/vulnerable/scan_result_overwrite/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "scan-result-overwrite"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban fixture where later scan results overwrite prior critical findings"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/scan_result_overwrite/src/lib.rs
+++ b/vulnerable/scan_result_overwrite/src/lib.rs
@@ -1,0 +1,141 @@
+//! VULNERABLE: Scan Result Overwrite Erases Prior Critical Finding
+//!
+//! Stores exactly one scan result per contract. Any later submission replaces
+//! the prior finding, so an informational result can erase a critical one.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
+
+pub mod secure;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum Severity {
+    Informational,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct ScanResult {
+    pub severity: Severity,
+    pub detail: String,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Result(Address),
+}
+
+#[contract]
+pub struct ScanResultOverwrite;
+
+#[contractimpl]
+impl ScanResultOverwrite {
+    pub fn submit(env: Env, contract: Address, severity: Severity, detail: String) {
+        let result = ScanResult { severity, detail };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Result(contract), &result);
+    }
+
+    pub fn latest(env: Env, contract: Address) -> Option<ScanResult> {
+        env.storage().persistent().get(&DataKey::Result(contract))
+    }
+
+    pub fn vulnerable_entry(env: Env, actor: Address, amount: i128) {
+        let detail = String::from_str(&env, "scanner hook");
+        let severity = if amount > 0 {
+            Severity::Informational
+        } else {
+            Severity::Critical
+        };
+        Self::submit(env, actor, severity, detail);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+    fn setup() -> (Env, ScanResultOverwriteClient<'static>, Address) {
+        let env = Env::default();
+        let id = env.register_contract(None, ScanResultOverwrite);
+        let client = ScanResultOverwriteClient::new(&env, &id);
+        let target = Address::generate(&env);
+        (env, client, target)
+    }
+
+    #[test]
+    fn vulnerable_path() {
+        let (env, client, target) = setup();
+        client.submit(
+            &target,
+            &Severity::Critical,
+            &String::from_str(&env, "critical"),
+        );
+        client.submit(
+            &target,
+            &Severity::Informational,
+            &String::from_str(&env, "info"),
+        );
+
+        let stored = client.latest(&target).unwrap();
+        assert_eq!(stored.severity, Severity::Informational);
+        assert_eq!(stored.detail, String::from_str(&env, "info"));
+    }
+
+    #[test]
+    fn boundary() {
+        let (env, client, target) = setup();
+        client.submit(
+            &target,
+            &Severity::Critical,
+            &String::from_str(&env, "first"),
+        );
+        client.submit(
+            &target,
+            &Severity::Critical,
+            &String::from_str(&env, "second"),
+        );
+
+        let stored = client.latest(&target).unwrap();
+        assert_eq!(stored.severity, Severity::Critical);
+        assert_eq!(stored.detail, String::from_str(&env, "second"));
+    }
+
+    #[test]
+    fn secure_path() {
+        use crate::secure::SecureScanResultsClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureScanResults);
+        let client = SecureScanResultsClient::new(&env, &id);
+        let target = Address::generate(&env);
+
+        client.submit(
+            &target,
+            &Severity::Critical,
+            &String::from_str(&env, "critical"),
+        );
+        client.submit(
+            &target,
+            &Severity::Informational,
+            &String::from_str(&env, "info"),
+        );
+
+        assert_eq!(
+            client.latest(&target).unwrap().severity,
+            Severity::Informational
+        );
+        assert_eq!(
+            client.highest(&target).unwrap().severity,
+            Severity::Critical
+        );
+        assert_eq!(client.history(&target).len(), 2);
+    }
+}

--- a/vulnerable/scan_result_overwrite/src/secure.rs
+++ b/vulnerable/scan_result_overwrite/src/secure.rs
@@ -1,0 +1,76 @@
+use crate::{ScanResult, Severity};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Vec};
+
+const HISTORY_CAP: u32 = 50;
+
+#[contracttype]
+pub enum DataKey {
+    Latest(Address),
+    Highest(Address),
+    History(Address),
+}
+
+#[contract]
+pub struct SecureScanResults;
+
+#[contractimpl]
+impl SecureScanResults {
+    pub fn submit(env: Env, contract: Address, severity: Severity, detail: String) {
+        let result = ScanResult { severity, detail };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Latest(contract.clone()), &result);
+
+        let highest = env
+            .storage()
+            .persistent()
+            .get::<_, ScanResult>(&DataKey::Highest(contract.clone()));
+        if highest
+            .as_ref()
+            .map(|prior| rank(&result.severity) >= rank(&prior.severity))
+            .unwrap_or(true)
+        {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Highest(contract.clone()), &result);
+        }
+
+        let mut history: Vec<ScanResult> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::History(contract.clone()))
+            .unwrap_or(Vec::new(&env));
+        if history.len() >= HISTORY_CAP {
+            history.pop_front();
+        }
+        history.push_back(result);
+        env.storage()
+            .persistent()
+            .set(&DataKey::History(contract), &history);
+    }
+
+    pub fn latest(env: Env, contract: Address) -> Option<ScanResult> {
+        env.storage().persistent().get(&DataKey::Latest(contract))
+    }
+
+    pub fn highest(env: Env, contract: Address) -> Option<ScanResult> {
+        env.storage().persistent().get(&DataKey::Highest(contract))
+    }
+
+    pub fn history(env: Env, contract: Address) -> Vec<ScanResult> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::History(contract))
+            .unwrap_or(Vec::new(&env))
+    }
+}
+
+fn rank(severity: &Severity) -> u32 {
+    match severity {
+        Severity::Informational => 0,
+        Severity::Low => 1,
+        Severity::Medium => 2,
+        Severity::High => 3,
+        Severity::Critical => 4,
+    }
+}


### PR DESCRIPTION
## Summary
Adds a focused Soroban fixture demonstrating that a later low-severity scan report
can silently overwrite a prior critical finding stored on-chain.

## Severity
Medium

## Crate
`vulnerable/scan_result_overwrite/`

## What the fixture shows
- `src/lib.rs`: single-slot storage per contract — any submission overwrites previous
- `src/secure.rs`: bounded history append; separate `highest_severity_result` never downgraded

## Tests
1. Vulnerable path: Critical → Informational submission loses critical state
2. Boundary: two Critical submissions — first is gone
3. Secure path: Critical → Informational — highest severity preserved, both in history

Closes #311