### PR TITLE
feat(vuln): add current_contract_admin vulnerable contract fixture

### DIFF
--- a/vulnerable/current_contract_admin/Cargo.toml
+++ b/vulnerable/current_contract_admin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "current-contract-admin"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban fixture where missing admin defaults to current contract address"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/current_contract_admin/src/lib.rs
+++ b/vulnerable/current_contract_admin/src/lib.rs
@@ -1,0 +1,114 @@
+//! VULNERABLE: Initialization Defaults Admin to Current Contract Address
+//!
+//! If no admin is supplied, the contract stores its own address as admin. No
+//! external signer can satisfy `require_auth()` for that address, so privileged
+//! functions are permanently locked.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Value,
+}
+
+#[contract]
+pub struct CurrentContractAdmin;
+
+#[contractimpl]
+impl CurrentContractAdmin {
+    pub fn initialize(env: Env, admin: Option<Address>) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        let stored = admin.unwrap_or_else(|| env.current_contract_address());
+        env.storage().persistent().set(&DataKey::Admin, &stored);
+    }
+
+    pub fn admin_action(env: Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Value, &1u32);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    pub fn value(env: Env) -> u32 {
+        env.storage().persistent().get(&DataKey::Value).unwrap_or(0)
+    }
+
+    pub fn vulnerable_entry(env: Env, _actor: Address, _amount: i128) {
+        Self::initialize(env, None);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, Address, CurrentContractAdminClient<'static>) {
+        let env = Env::default();
+        let id = env.register_contract(None, CurrentContractAdmin);
+        let client = CurrentContractAdminClient::new(&env, &id);
+        (env, id, client)
+    }
+
+    #[test]
+    fn vulnerable_path() {
+        let (_env, id, client) = setup();
+        client.initialize(&None);
+        assert_eq!(client.get_admin(), id);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.admin_action();
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn boundary() {
+        let (env, _id, client) = setup();
+        let real_admin = Address::generate(&env);
+        client.initialize(&None);
+        assert_ne!(client.get_admin(), real_admin);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.admin_action();
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn secure_path() {
+        use crate::secure::SecureCurrentContractAdminClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureCurrentContractAdmin);
+        let client = SecureCurrentContractAdminClient::new(&env, &id);
+
+        let missing = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.initialize_required(&None);
+        }));
+        assert!(missing.is_err());
+
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.admin_action();
+        assert_eq!(client.value(), 1);
+    }
+}

--- a/vulnerable/current_contract_admin/src/secure.rs
+++ b/vulnerable/current_contract_admin/src/secure.rs
@@ -1,0 +1,62 @@
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    PendingAdmin,
+    Value,
+}
+
+#[contract]
+pub struct SecureCurrentContractAdmin;
+
+#[contractimpl]
+impl SecureCurrentContractAdmin {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn initialize_required(env: Env, admin: Option<Address>) {
+        let admin = admin.expect("admin required");
+        Self::initialize(env, admin);
+    }
+
+    pub fn nominate_admin(env: Env, nominee: Address) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &nominee);
+    }
+
+    pub fn accept_admin(env: Env) {
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .expect("no pending admin");
+        pending.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &pending);
+    }
+
+    pub fn admin_action(env: Env) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Value, &1u32);
+    }
+
+    pub fn value(env: Env) -> u32 {
+        env.storage().persistent().get(&DataKey::Value).unwrap_or(0)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a focused Soroban fixture demonstrating that defaulting the admin role to the
contract's own address at initialization permanently locks all privileged functions —
no external signer can ever satisfy `require_auth()` for the contract address.

## Severity
Critical

## Crate
`vulnerable/current_contract_admin/`

## What the fixture shows
- `src/lib.rs`: `initialize(admin: Option<Address>)` falls back to `env.current_contract_address()` — locks contract forever
- `src/secure.rs`: admin is a required parameter with no fallback; two-step accept flow variant shown

## Tests
1. Vulnerable path: init with None → admin is contract address → admin_action unreachable
2. Boundary: attempt admin_action with real signer after bad init → rejected
3. Secure path: init without admin panics; init with real admin → admin_action works

Closes #301