### PR TITLE
feat(vuln): add governance_target_unvalidated vulnerable contract fixture

### DIFF
--- a/vulnerable/governance_target_unvalidated/Cargo.toml
+++ b/vulnerable/governance_target_unvalidated/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "governance-target-unvalidated"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban fixture where governance calls arbitrary unallowlisted targets"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/governance_target_unvalidated/src/lib.rs
+++ b/vulnerable/governance_target_unvalidated/src/lib.rs
@@ -1,0 +1,144 @@
+//! VULNERABLE: Governance Call Target Is Not Allowlisted
+//!
+//! Passed proposals can execute arbitrary target/function pairs. The DAO never
+//! checks that a target or function is approved.
+
+#![no_std]
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Val, Vec,
+};
+
+pub mod secure;
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Proposal {
+    pub target: Address,
+    pub function: Symbol,
+    pub args: Vec<Val>,
+}
+
+#[contracttype]
+pub enum DataKey {
+    NextId,
+    Proposal(u64),
+    Executed(u64),
+}
+
+#[contract]
+pub struct GovernanceTargetUnvalidated;
+
+#[contractimpl]
+impl GovernanceTargetUnvalidated {
+    pub fn propose(env: Env, proposal: Proposal) -> u64 {
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextId)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(id), &proposal);
+        env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+        id
+    }
+
+    pub fn execute(env: Env, proposal_id: u64) -> Val {
+        let proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("proposal missing");
+        let result: Val = env.invoke_contract(&proposal.target, &proposal.function, proposal.args);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Executed(proposal_id), &true);
+        result
+    }
+
+    pub fn executed(env: Env, proposal_id: u64) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Executed(proposal_id))
+            .unwrap_or(false)
+    }
+
+    pub fn dao_ping(_env: Env) -> u32 {
+        7
+    }
+
+    pub fn vulnerable_entry(env: Env, actor: Address, amount: i128) {
+        let proposal = Proposal {
+            target: actor,
+            function: symbol_short!("ping"),
+            args: Vec::new(&env),
+        };
+        let _ = Self::propose(env, proposal);
+        let _ = amount;
+    }
+}
+
+#[contract]
+pub struct UnintendedTarget;
+
+#[contractimpl]
+impl UnintendedTarget {
+    pub fn ping(_env: Env) -> u32 {
+        42
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{Env, IntoVal};
+
+    #[test]
+    fn vulnerable_path() {
+        let env = Env::default();
+        let dao_id = env.register_contract(None, GovernanceTargetUnvalidated);
+        let target_id = env.register_contract(None, UnintendedTarget);
+        let dao = GovernanceTargetUnvalidatedClient::new(&env, &dao_id);
+
+        let proposal = Proposal {
+            target: target_id,
+            function: symbol_short!("ping"),
+            args: Vec::new(&env),
+        };
+        let id = dao.propose(&proposal);
+        assert_eq!(dao.execute(&id), 42u32.into_val(&env));
+        assert!(dao.executed(&id));
+    }
+
+    #[test]
+    fn boundary() {
+        let env = Env::default();
+        let dao_id = env.register_contract(None, GovernanceTargetUnvalidated);
+        let dao = GovernanceTargetUnvalidatedClient::new(&env, &dao_id);
+
+        let proposal = Proposal {
+            target: dao_id.clone(),
+            function: symbol_short!("dao_ping"),
+            args: Vec::new(&env),
+        };
+        let id = dao.propose(&proposal);
+        assert_eq!(dao.execute(&id), 7u32.into_val(&env));
+    }
+
+    #[test]
+    fn secure_path() {
+        use crate::secure::SecureGovernanceClient;
+
+        let env = Env::default();
+        let gov_id = env.register_contract(None, secure::SecureGovernance);
+        let target_id = env.register_contract(None, UnintendedTarget);
+        let gov = SecureGovernanceClient::new(&env, &gov_id);
+
+        let proposal = Proposal {
+            target: target_id,
+            function: symbol_short!("ping"),
+            args: Vec::new(&env),
+        };
+        assert!(gov.try_propose(&proposal).is_err());
+    }
+}

--- a/vulnerable/governance_target_unvalidated/src/secure.rs
+++ b/vulnerable/governance_target_unvalidated/src/secure.rs
@@ -1,0 +1,95 @@
+use crate::Proposal;
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, Env, Symbol, Val, Vec,
+};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ContractError {
+    TargetNotAllowed = 1,
+    FunctionNotAllowed = 2,
+}
+
+#[contracttype]
+pub enum DataKey {
+    NextId,
+    Proposal(u64),
+    AllowedTargets,
+    AllowedFunctions,
+}
+
+#[contract]
+pub struct SecureGovernance;
+
+#[contractimpl]
+impl SecureGovernance {
+    pub fn allow_target(env: Env, target: Address) {
+        let mut targets: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AllowedTargets)
+            .unwrap_or(Vec::new(&env));
+        targets.push_back(target);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowedTargets, &targets);
+    }
+
+    pub fn allow_function(env: Env, function: Symbol) {
+        let mut functions: Vec<Symbol> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AllowedFunctions)
+            .unwrap_or(Vec::new(&env));
+        functions.push_back(function);
+        env.storage()
+            .persistent()
+            .set(&DataKey::AllowedFunctions, &functions);
+    }
+
+    pub fn propose(env: Env, proposal: Proposal) -> Result<u64, ContractError> {
+        ensure_allowed(&env, &proposal)?;
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextId)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(id), &proposal);
+        env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+        Ok(id)
+    }
+
+    pub fn execute(env: Env, proposal_id: u64) -> Result<Val, ContractError> {
+        let proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .expect("proposal missing");
+        ensure_allowed(&env, &proposal)?;
+        Ok(env.invoke_contract(&proposal.target, &proposal.function, proposal.args))
+    }
+}
+
+fn ensure_allowed(env: &Env, proposal: &Proposal) -> Result<(), ContractError> {
+    let targets: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::AllowedTargets)
+        .unwrap_or(Vec::new(env));
+    if !targets.contains(&proposal.target) {
+        return Err(ContractError::TargetNotAllowed);
+    }
+
+    let functions: Vec<Symbol> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::AllowedFunctions)
+        .unwrap_or(Vec::new(env));
+    if !functions.contains(&proposal.function) {
+        return Err(ContractError::FunctionNotAllowed);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Adds a focused Soroban fixture demonstrating that a DAO with no target allowlist can
execute arbitrary calls to any address after a proposal passes — enabling malicious
proposals to drain tokens, call unrelated contracts, or re-enter the DAO itself.

## Severity
High

## Crate
`vulnerable/governance_target_unvalidated/`

## What the fixture shows
- `src/lib.rs`: `propose()` accepts any target/function with no validation; `execute()` calls blindly
- `src/secure.rs`: target and function allowlists enforced at propose and execute time

## Tests
1. Vulnerable path: unintended target proposal → execute() calls it successfully
2. Boundary: proposal targeting DAO itself → vulnerable impl executes it
3. Secure path: same proposal → rejected at propose() or execute() — not in allowlist

Closes #297