### PR TITLE
Add vulnerable security fixtures for partial config update, ledger sequence misuse, missing user balance key, and unbound report hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,10 @@ members = [
     "vulnerable/signed_unsigned_wrap",
     "vulnerable/abs_min_overflow",
     "vulnerable/negative_oracle_price",
+    "vulnerable/partial_config_clear",
+    "vulnerable/sequence_as_timestamp",
+    "vulnerable/balance_key_missing_user",
+    "vulnerable/report_hash_unbound_contract",
 ]
 
 [workspace.dependencies]

--- a/vulnerable/balance_key_missing_user/Cargo.toml
+++ b/vulnerable/balance_key_missing_user/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "balance-key-missing-user"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating asset-only balance keys without user scoping"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/balance_key_missing_user/src/lib.rs
+++ b/vulnerable/balance_key_missing_user/src/lib.rs
@@ -1,0 +1,74 @@
+//! VULNERABLE: Balance storage key omits the user.
+//!
+//! A market that stores balances by asset only. Deposits from different users
+//! using the same asset overwrite each other, enabling theft or denial of
+//! service.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Balance(Symbol),
+    UserBalance(Symbol, Address),
+}
+
+#[contract]
+pub struct BalanceKeyMissingUserContract;
+
+#[contractimpl]
+impl BalanceKeyMissingUserContract {
+    pub fn deposit(env: Env, user: Address, asset: Symbol, amount: i128) {
+        user.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(asset), &amount);
+    }
+
+    pub fn balance(env: Env, asset: Symbol) -> i128 {
+        env.storage().persistent().get(&DataKey::Balance(asset)).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    #[test]
+    fn test_vulnerable_deposit_same_asset_overwrites_previous_user() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, BalanceKeyMissingUserContract);
+        let client = BalanceKeyMissingUserContractClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let asset = symbol_short!("USDC");
+
+        env.mock_all_auths();
+        client.deposit(&alice, &asset, &100);
+        assert_eq!(client.balance(&asset), 100);
+
+        client.deposit(&bob, &asset, &200);
+        assert_eq!(client.balance(&asset), 200);
+    }
+
+    #[test]
+    fn test_secure_balance_isolated_by_user() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, secure::SecureBalanceKeyMissingUserContract);
+        let client = secure::SecureBalanceKeyMissingUserContractClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        let asset = symbol_short!("USDC");
+
+        env.mock_all_auths();
+        client.deposit(&alice, &asset, &100);
+        client.deposit(&bob, &asset, &200);
+
+        assert_eq!(client.balance(&alice, &asset), 100);
+        assert_eq!(client.balance(&bob, &asset), 200);
+    }
+}

--- a/vulnerable/balance_key_missing_user/src/secure.rs
+++ b/vulnerable/balance_key_missing_user/src/secure.rs
@@ -1,0 +1,24 @@
+//! SECURE: Include the user identity in balance storage keys.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol};
+use super::DataKey;
+
+#[contract]
+pub struct SecureBalanceKeyMissingUserContract;
+
+#[contractimpl]
+impl SecureBalanceKeyMissingUserContract {
+    pub fn deposit(env: Env, user: Address, asset: Symbol, amount: i128) {
+        user.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::UserBalance(asset, user), &amount);
+    }
+
+    pub fn balance(env: Env, user: Address, asset: Symbol) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::UserBalance(asset, user))
+            .unwrap_or(0)
+    }
+}

--- a/vulnerable/partial_config_clear/Cargo.toml
+++ b/vulnerable/partial_config_clear/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "partial-config-clear"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating partial config updates clearing omitted fields"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/partial_config_clear/src/lib.rs
+++ b/vulnerable/partial_config_clear/src/lib.rs
@@ -1,0 +1,122 @@
+//! VULNERABLE: Partial config update clears omitted fields.
+//!
+//! A configuration contract that accepts optional update fields but rewrites the
+//! full config struct using defaults for omitted values. A caller who updates one
+//! field can silently reset fees, caps, or oracle settings.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Config,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Config {
+    pub fee_bps: u32,
+    pub max_cap: i128,
+    pub oracle: Option<Address>,
+}
+
+#[contract]
+pub struct PartialConfigClearContract;
+
+#[contractimpl]
+impl PartialConfigClearContract {
+    pub fn initialize(env: Env, admin: Address, fee_bps: u32, max_cap: i128, oracle: Address) {
+        admin.require_auth();
+        let config = Config {
+            fee_bps,
+            max_cap,
+            oracle: Some(oracle),
+        };
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Config, &config);
+    }
+
+    pub fn update_config(
+        env: Env,
+        actor: Address,
+        fee_bps: Option<u32>,
+        max_cap: Option<i128>,
+        oracle: Option<Address>,
+    ) {
+        actor.require_auth();
+
+        // BUG: partial update rebuilds the config from defaults for omitted
+        // fields, silently clearing values that were previously set.
+        let config = Config {
+            fee_bps: fee_bps.unwrap_or(0),
+            max_cap: max_cap.unwrap_or(0),
+            oracle,
+        };
+        env.storage().persistent().set(&DataKey::Config, &config);
+    }
+
+    pub fn get_config(env: Env) -> Config {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("config not initialized")
+    }
+}
+
+pub fn validate_config(config: &Config) {
+    assert!(config.fee_bps <= 10_000, "fee too high");
+    assert!(config.max_cap > 0, "cap must be positive");
+    assert!(config.oracle.is_some(), "oracle is required");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, PartialConfigClearContractClient<'static>) {
+        let env = Env::default();
+        let id = env.register_contract(None, PartialConfigClearContract);
+        let client = PartialConfigClearContractClient::new(&env, &id);
+        (env, client)
+    }
+
+    #[test]
+    fn test_vulnerable_partial_update_clears_omitted_fields() {
+        let (env, client) = setup();
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.initialize(&admin, &100, &1000, &oracle);
+        client.update_config(&admin, &Some(250), &None, &None);
+
+        let config = client.get_config();
+        assert_eq!(config.fee_bps, 250);
+        assert_eq!(config.max_cap, 0);
+        assert_eq!(config.oracle, None);
+    }
+
+    #[test]
+    fn test_secure_partial_update_preserves_omitted_fields() {
+        let env = Env::default();
+        let id = env.register_contract(None, PartialConfigClearContract);
+        let client = PartialConfigClearContractClient::new(&env, &id);
+        let secure_id = env.register_contract(None, secure::SecureContract);
+        let secure_client = secure::SecureContractClient::new(&env, &secure_id);
+
+        let admin = Address::generate(&env);
+        let oracle = Address::generate(&env);
+
+        env.mock_all_auths();
+        secure_client.initialize(&admin, &100, &1000, &oracle);
+        secure_client.update_config(&admin, &Some(250), &None, &None);
+
+        let secure_config = secure_client.get_config();
+        assert_eq!(secure_config.fee_bps, 250);
+        assert_eq!(secure_config.max_cap, 1000);
+        assert_eq!(secure_config.oracle, Some(oracle));
+    }
+}

--- a/vulnerable/partial_config_clear/src/secure.rs
+++ b/vulnerable/partial_config_clear/src/secure.rs
@@ -1,0 +1,56 @@
+//! SECURE: Merge partial configuration updates.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, Address, Env};
+use super::{validate_config, Config, DataKey};
+
+#[contract]
+pub struct SecureContract;
+
+#[contractimpl]
+impl SecureContract {
+    pub fn initialize(env: Env, admin: Address, fee_bps: u32, max_cap: i128, oracle: Address) {
+        admin.require_auth();
+        let config = Config {
+            fee_bps,
+            max_cap,
+            oracle: Some(oracle),
+        };
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Config, &config);
+    }
+
+    pub fn update_config(
+        env: Env,
+        actor: Address,
+        fee_bps: Option<u32>,
+        max_cap: Option<i128>,
+        oracle: Option<Address>,
+    ) {
+        actor.require_auth();
+        let mut config: Config = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("config not initialized");
+
+        if let Some(fee) = fee_bps {
+            config.fee_bps = fee;
+        }
+        if let Some(cap) = max_cap {
+            config.max_cap = cap;
+        }
+        if let Some(oracle) = oracle {
+            config.oracle = Some(oracle);
+        }
+
+        validate_config(&config);
+        env.storage().persistent().set(&DataKey::Config, &config);
+    }
+
+    pub fn get_config(env: Env) -> Config {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .expect("config not initialized")
+    }
+}

--- a/vulnerable/report_hash_unbound_contract/Cargo.toml
+++ b/vulnerable/report_hash_unbound_contract/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "report-hash-unbound-contract"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating signed reports missing target contract binding"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/report_hash_unbound_contract/src/lib.rs
+++ b/vulnerable/report_hash_unbound_contract/src/lib.rs
@@ -1,0 +1,99 @@
+//! VULNERABLE: Report hash signature omits the contract address.
+//!
+//! A registry-like report submission contract that verifies a signed report hash
+//! but does not bind the signed payload to the target contract address. A valid
+//! report for one contract can be replayed against another.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Report(Address),
+}
+
+pub fn vulnerable_report_signature(env: &Env, report_hash: &BytesN<32>) -> BytesN<32> {
+    let mut msg = Bytes::new(env);
+    msg.append(&report_hash.to_xdr(env));
+    env.crypto().sha256(&msg).into()
+}
+
+#[contract]
+pub struct ReportHashUnboundContract;
+
+#[contractimpl]
+impl ReportHashUnboundContract {
+    pub fn submit_report(
+        env: Env,
+        scanner: Address,
+        target_contract: Address,
+        report_hash: BytesN<32>,
+        signature: BytesN<32>,
+    ) {
+        scanner.require_auth();
+        let expected = vulnerable_report_signature(&env, &report_hash);
+        assert_eq!(signature, expected, "invalid report signature");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Report(target_contract), &report_hash);
+    }
+
+    pub fn get_report(env: Env, target_contract: Address) -> Option<BytesN<32>> {
+        env.storage().persistent().get(&DataKey::Report(target_contract))
+    }
+
+    pub fn report_signature(env: Env, report_hash: BytesN<32>) -> BytesN<32> {
+        vulnerable_report_signature(&env, &report_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+
+    #[test]
+    fn test_vulnerable_report_replay_across_target_contracts() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, ReportHashUnboundContract);
+        let client = ReportHashUnboundContractClient::new(&env, &contract_id);
+
+        let scanner = Address::generate(&env);
+        let target_contract_a = Address::generate(&env);
+        let target_contract_b = Address::generate(&env);
+        let report_hash = BytesN::from_array(&env, &[1u8; 32]);
+
+        env.mock_all_auths();
+        let signature = client.report_signature(&report_hash);
+
+        client.submit_report(&scanner, &target_contract_a, &report_hash, &signature);
+        client.submit_report(&scanner, &target_contract_b, &report_hash, &signature);
+
+        assert_eq!(client.get_report(&target_contract_a), Some(report_hash));
+        assert_eq!(client.get_report(&target_contract_b), Some(report_hash));
+    }
+
+    #[test]
+    fn test_secure_report_replay_fails_between_targets() {
+        let env = Env::default();
+        let secure_id = env.register_contract(None, secure::SecureReportHashUnboundContract);
+        let client = secure::SecureReportHashUnboundContractClient::new(&env, &secure_id);
+
+        let scanner = Address::generate(&env);
+        let target_contract_a = Address::generate(&env);
+        let target_contract_b = Address::generate(&env);
+        let report_hash = BytesN::from_array(&env, &[1u8; 32]);
+        let nonce = 1u64;
+
+        env.mock_all_auths();
+        let signature_a = client.report_signature(&scanner, &target_contract_a, &report_hash, &nonce);
+
+        client.submit_report(&scanner, &target_contract_a, &report_hash, &nonce, &signature_a);
+
+        let result = std::panic::catch_unwind(|| {
+            client.submit_report(&scanner, &target_contract_b, &report_hash, &nonce, &signature_a);
+        });
+        assert!(result.is_err());
+    }
+}

--- a/vulnerable/report_hash_unbound_contract/src/secure.rs
+++ b/vulnerable/report_hash_unbound_contract/src/secure.rs
@@ -1,0 +1,55 @@
+//! SECURE: Bind signed reports to the target contract and scanner identity.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env};
+use super::DataKey;
+
+pub fn secure_report_signature(
+    env: &Env,
+    target_contract: &Address,
+    scanner: &Address,
+    report_hash: &BytesN<32>,
+    nonce: u64,
+) -> BytesN<32> {
+    let mut msg = Bytes::new(env);
+    msg.append(&target_contract.to_xdr(env));
+    msg.append(&scanner.to_xdr(env));
+    msg.append(&report_hash.to_xdr(env));
+    msg.append(&Bytes::from_array(env, &nonce.to_be_bytes()));
+    env.crypto().sha256(&msg).into()
+}
+
+#[contract]
+pub struct SecureReportHashUnboundContract;
+
+#[contractimpl]
+impl SecureReportHashUnboundContract {
+    pub fn submit_report(
+        env: Env,
+        scanner: Address,
+        target_contract: Address,
+        report_hash: BytesN<32>,
+        nonce: u64,
+        signature: BytesN<32>,
+    ) {
+        scanner.require_auth();
+        let expected = secure_report_signature(&env, &target_contract, &scanner, &report_hash, nonce);
+        assert_eq!(signature, expected, "invalid report signature");
+        env.storage()
+            .persistent()
+            .set(&DataKey::Report(target_contract), &report_hash);
+    }
+
+    pub fn get_report(env: Env, target_contract: Address) -> Option<BytesN<32>> {
+        env.storage().persistent().get(&DataKey::Report(target_contract))
+    }
+
+    pub fn report_signature(
+        env: Env,
+        scanner: Address,
+        target_contract: Address,
+        report_hash: BytesN<32>,
+        nonce: u64,
+    ) -> BytesN<32> {
+        secure_report_signature(&env, &target_contract, &scanner, &report_hash, nonce)
+    }
+}

--- a/vulnerable/sequence_as_timestamp/Cargo.toml
+++ b/vulnerable/sequence_as_timestamp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sequence-as-timestamp"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating ledger sequence treated as timestamp units"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/sequence_as_timestamp/src/lib.rs
+++ b/vulnerable/sequence_as_timestamp/src/lib.rs
@@ -1,0 +1,110 @@
+//! VULNERABLE: Ledger sequence treated as timestamp units.
+//!
+//! A vesting-style lock that uses a duration expressed in seconds to compute an
+//! unlock ledger sequence. Ledger sequence numbers are not seconds, so the lock
+//! period becomes much longer or shorter than intended.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Balance(Address),
+    UnlockSequence(Address),
+}
+
+#[contract]
+pub struct SequenceAsTimestampContract;
+
+#[contractimpl]
+impl SequenceAsTimestampContract {
+    pub fn deposit(env: Env, user: Address, amount: i128, duration_seconds: u32) {
+        user.require_auth();
+
+        let balance_key = DataKey::Balance(user.clone());
+        let current_balance: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&balance_key, &(current_balance + amount));
+
+        // BUG: treats `duration_seconds` as ledger sequence steps.
+        let unlock_sequence = env.ledger().sequence() + duration_seconds;
+        env.storage()
+            .persistent()
+            .set(&DataKey::UnlockSequence(user), &unlock_sequence);
+    }
+
+    pub fn withdraw(env: Env, user: Address) {
+        user.require_auth();
+
+        let unlock_sequence: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UnlockSequence(user.clone()))
+            .expect("unlock not set");
+
+        if env.ledger().sequence() < unlock_sequence {
+            panic!("still locked");
+        }
+
+        env.storage().persistent().set(&DataKey::Balance(user.clone()), &0i128);
+        env.storage().persistent().remove(&DataKey::UnlockSequence(user));
+    }
+
+    pub fn balance(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(user))
+            .unwrap_or(0)
+    }
+
+    pub fn unlock_sequence(env: Env, user: Address) -> Option<u32> {
+        env.storage().persistent().get(&DataKey::UnlockSequence(user))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Ledger as _, testutils::Address as _, Address, Env};
+
+    #[test]
+    fn test_vulnerable_lock_does_not_unlock_after_one_day_timestamp_advance() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SequenceAsTimestampContract);
+        let client = SequenceAsTimestampContractClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let duration = 86_400u32;
+
+        env.mock_all_auths();
+        client.deposit(&alice, &1000, &duration);
+
+        let current_timestamp = env.ledger().timestamp();
+        env.ledger().set_timestamp(current_timestamp + u64::from(duration));
+
+        let result = std::panic::catch_unwind(|| client.withdraw(&alice));
+        assert!(result.is_err());
+        assert_eq!(client.balance(&alice), 1000);
+    }
+
+    #[test]
+    fn test_secure_timestamp_lock_unlocks_after_one_day() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, secure::SecureSequenceAsTimestampContract);
+        let client = secure::SecureSequenceAsTimestampContractClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let duration = 86_400u32;
+
+        env.mock_all_auths();
+        client.deposit(&alice, &1000, &duration);
+
+        let current_timestamp = env.ledger().timestamp();
+        env.ledger().set_timestamp(current_timestamp + u64::from(duration));
+
+        client.withdraw(&alice);
+        assert_eq!(client.balance(&alice), 0);
+    }
+}

--- a/vulnerable/sequence_as_timestamp/src/secure.rs
+++ b/vulnerable/sequence_as_timestamp/src/secure.rs
@@ -1,0 +1,53 @@
+//! SECURE: Use ledger timestamps for duration-based locks.
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+use super::DataKey;
+
+#[contract]
+pub struct SecureSequenceAsTimestampContract;
+
+#[contractimpl]
+impl SecureSequenceAsTimestampContract {
+    pub fn deposit(env: Env, user: Address, amount: i128, duration_seconds: u32) {
+        user.require_auth();
+
+        let balance_key = DataKey::Balance(user.clone());
+        let current_balance: i128 = env.storage().persistent().get(&balance_key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&balance_key, &(current_balance + amount));
+
+        let unlock_timestamp = env.ledger().timestamp() + u64::from(duration_seconds);
+        env.storage()
+            .persistent()
+            .set(&DataKey::UnlockSequence(user), &unlock_timestamp);
+    }
+
+    pub fn withdraw(env: Env, user: Address) {
+        user.require_auth();
+
+        let unlock_timestamp: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UnlockSequence(user.clone()))
+            .expect("unlock not set");
+
+        if env.ledger().timestamp() < unlock_timestamp {
+            panic!("still locked");
+        }
+
+        env.storage().persistent().set(&DataKey::Balance(user.clone()), &0i128);
+        env.storage().persistent().remove(&DataKey::UnlockSequence(user));
+    }
+
+    pub fn balance(env: Env, user: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(user))
+            .unwrap_or(0)
+    }
+
+    pub fn unlock_timestamp(env: Env, user: Address) -> Option<u64> {
+        env.storage().persistent().get(&DataKey::UnlockSequence(user))
+    }
+}


### PR DESCRIPTION
closes #302 
closes #303
closes #304 
closes #310 

This PR adds four focused vulnerable fixture crates to the repository:

[partial_config_clear](vscode-file://vscode-app/c:/Users/HP%20PC/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Demonstrates unsafe partial config updates that rebuild full config with defaults and reset omitted settings.
[sequence_as_timestamp](vscode-file://vscode-app/c:/Users/HP%20PC/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Demonstrates using ledger sequence as a timestamp, causing incorrect duration handling.
[balance_key_missing_user](vscode-file://vscode-app/c:/Users/HP%20PC/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Demonstrates asset balance storage keyed only by asset, allowing deposits from different users to overwrite one another.
[report_hash_unbound_contract](vscode-file://vscode-app/c:/Users/HP%20PC/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Demonstrates signed report validation omitting the contract address, enabling report reuse across contracts.
Each crate includes:

src/lib.rs with the vulnerable fixture implementation
src/secure.rs with a secure comparison implementation
[Cargo.toml](vscode-file://vscode-app/c:/Users/HP%20PC/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Also updated workspace configuration in [Cargo.toml](vscode-file://vscode-app/c:/Users/HP%20PC/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include the new fixtures.

Notes
Branch: add-vulnerable-security-fixtures
Changes have been committed and pushed
Tests were not run per request