### PR TITLE
feat(vuln): add proposal_id_collision vulnerable contract fixture

### DIFF
--- a/vulnerable/proposal_id_collision/Cargo.toml
+++ b/vulnerable/proposal_id_collision/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "proposal-id-collision"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban fixture where duplicate proposal IDs overwrite voting state"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/proposal_id_collision/src/lib.rs
+++ b/vulnerable/proposal_id_collision/src/lib.rs
@@ -1,0 +1,128 @@
+//! VULNERABLE: Proposal ID Collision Overwrites Active Proposals
+//!
+//! Proposal identity is derived only from proposer and title. A second proposal
+//! with the same pair overwrites the first proposal and its votes.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Symbol};
+
+pub mod secure;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct Proposal {
+    pub proposer: Address,
+    pub title: Symbol,
+    pub payload: Bytes,
+    pub votes: u32,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Proposal(Address, Symbol),
+}
+
+#[contract]
+pub struct ProposalIdCollision;
+
+#[contractimpl]
+impl ProposalIdCollision {
+    pub fn propose(env: Env, proposer: Address, title: Symbol, payload: Bytes) {
+        let proposal = Proposal {
+            proposer: proposer.clone(),
+            title: title.clone(),
+            payload,
+            votes: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposer, title), &proposal);
+    }
+
+    pub fn vote(env: Env, proposer: Address, title: Symbol) {
+        let key = DataKey::Proposal(proposer, title);
+        let mut proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("proposal missing");
+        proposal.votes += 1;
+        env.storage().persistent().set(&key, &proposal);
+    }
+
+    pub fn get(env: Env, proposer: Address, title: Symbol) -> Proposal {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposer, title))
+            .expect("proposal missing")
+    }
+
+    pub fn vulnerable_entry(env: Env, actor: Address, amount: i128) {
+        let mut payload = Bytes::new(&env);
+        payload.push_back(amount as u8);
+        Self::propose(env, actor, Symbol::new(&env, "audit"), payload);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Bytes, Env, Symbol};
+
+    fn bytes(env: &Env, value: u8) -> Bytes {
+        let mut bytes = Bytes::new(env);
+        bytes.push_back(value);
+        bytes
+    }
+
+    #[test]
+    fn vulnerable_path() {
+        let env = Env::default();
+        let id = env.register_contract(None, ProposalIdCollision);
+        let client = ProposalIdCollisionClient::new(&env, &id);
+        let proposer = Address::generate(&env);
+        let title = Symbol::new(&env, "upgrade");
+
+        client.propose(&proposer, &title, &bytes(&env, 1));
+        client.propose(&proposer, &title, &bytes(&env, 2));
+
+        let stored = client.get(&proposer, &title);
+        assert_eq!(stored.payload, bytes(&env, 2));
+        assert_eq!(stored.votes, 0);
+    }
+
+    #[test]
+    fn boundary() {
+        let env = Env::default();
+        let id = env.register_contract(None, ProposalIdCollision);
+        let client = ProposalIdCollisionClient::new(&env, &id);
+        let proposer = Address::generate(&env);
+        let title = Symbol::new(&env, "upgrade");
+
+        client.propose(&proposer, &title, &bytes(&env, 1));
+        client.vote(&proposer, &title);
+        assert_eq!(client.get(&proposer, &title).votes, 1);
+
+        client.propose(&proposer, &title, &bytes(&env, 2));
+        assert_eq!(client.get(&proposer, &title).votes, 0);
+    }
+
+    #[test]
+    fn secure_path() {
+        use crate::secure::SecureProposalIdsClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureProposalIds);
+        let client = SecureProposalIdsClient::new(&env, &id);
+        let proposer = Address::generate(&env);
+        let title = Symbol::new(&env, "upgrade");
+
+        let first = client.propose(&proposer, &title, &bytes(&env, 1));
+        client.vote(&first);
+        let second = client.propose(&proposer, &title, &bytes(&env, 2));
+
+        assert_ne!(first, second);
+        assert_eq!(client.get(&first).votes, 1);
+        assert_eq!(client.get(&second).votes, 0);
+    }
+}

--- a/vulnerable/proposal_id_collision/src/secure.rs
+++ b/vulnerable/proposal_id_collision/src/secure.rs
@@ -1,0 +1,51 @@
+use crate::Proposal;
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Symbol};
+
+#[contracttype]
+pub enum DataKey {
+    NextId,
+    Proposal(u64),
+}
+
+#[contract]
+pub struct SecureProposalIds;
+
+#[contractimpl]
+impl SecureProposalIds {
+    pub fn propose(env: Env, proposer: Address, title: Symbol, payload: Bytes) -> u64 {
+        let id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NextId)
+            .unwrap_or(0);
+        let proposal = Proposal {
+            proposer,
+            title,
+            payload,
+            votes: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(id), &proposal);
+        env.storage().persistent().set(&DataKey::NextId, &(id + 1));
+        id
+    }
+
+    pub fn vote(env: Env, id: u64) {
+        let key = DataKey::Proposal(id);
+        let mut proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .expect("proposal missing");
+        proposal.votes += 1;
+        env.storage().persistent().set(&key, &proposal);
+    }
+
+    pub fn get(env: Env, id: u64) -> Proposal {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Proposal(id))
+            .expect("proposal missing")
+    }
+}


### PR DESCRIPTION
## Summary
Adds a focused Soroban fixture demonstrating that deriving proposal IDs solely from
proposer address and title allows a duplicate submission to silently overwrite an
active proposal and erase all accumulated votes.

## Severity
Critical

## Crate
`vulnerable/proposal_id_collision/`

## What the fixture shows
- `src/lib.rs`: ID = hash(proposer, title) — second same-title proposal overwrites first and clears votes
- `src/secure.rs`: monotonically increasing counter ID — every proposal gets a unique slot

## Tests
1. Vulnerable path: two same-title proposals from same proposer → second overwrites first
2. Boundary: votes added to first proposal then duplicate submitted → vote count wiped
3. Secure path: same sequence → both proposals exist with distinct IDs, votes intact

Closes #290