### PR TITLE
feat(accept_admin_missing_auth): add vulnerable/secure pair for accept_admin missing auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "vulnerable/signed_unsigned_wrap",
     "vulnerable/abs_min_overflow",
     "vulnerable/negative_oracle_price",
+    "vulnerable/stale_pending_admin",
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
+    "vulnerable/abs_min_overflow",
+    "vulnerable/accept_admin_missing_auth",
     "vulnerable/admin_rugpull",
     "vulnerable/allowance_not_decremented",
     "vulnerable/call_depth",
@@ -85,7 +87,6 @@ members = [
     "vulnerable/oracle_price_scale_mismatch",
     "vulnerable/mixed_collateral_decimals",
     "vulnerable/signed_unsigned_wrap",
-    "vulnerable/abs_min_overflow",
     "vulnerable/negative_oracle_price",
     "vulnerable/stale_pending_admin",
 ]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ soroban-guard-contracts/
 
 | Crate | Context | Vulnerability |
 |---|---|---|
+| [`accept_admin_missing_auth`](./vulnerable/accept_admin_missing_auth/README.md) | Admin contract | `accept_admin()` never calls `require_auth` — anyone can finalise the transfer |
 | [`missing_auth`](./vulnerable/missing_auth/README.md) | Token contract | `transfer()` mutates balances without `require_auth()` |
 | [`missing_ttl`](./vulnerable/missing_ttl/README.md) | Token contract | Persistent balances expire because the contract never calls `extend_ttl()` |
 | [`unchecked_math`](./vulnerable/unchecked_math/README.md) | Staking contract | Reward calc uses raw `*` on `u64` — overflows silently |

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ soroban-guard-contracts/
 | [`self_transfer`](./vulnerable/self_transfer/README.md) | Token contract | `from == to` corrupts balance accounting |
 | [`sensitive_storage`](./vulnerable/sensitive_storage/README.md) | Registry contract | Secrets stored in publicly readable contract storage |
 | [`stale_oracle`](./vulnerable/stale_oracle/README.md) | DEX contract | Oracle price used without staleness check |
+| [`stale_pending_admin`](./vulnerable/stale_pending_admin/README.md) | Admin contract | Two-step admin: cancellation does not clear pending admin — stale address can still accept |
 | [`string_admin`](./vulnerable/string_admin/README.md) | Admin contract | Admin stored as `String` — bypasses `require_auth` |
 | [`timestamp_lock`](./vulnerable/timestamp_lock/README.md) | Vault contract | Time-lock uses manipulable `ledger().timestamp()` |
 | [`unbounded_storage`](./vulnerable/unbounded_storage/README.md) | Registry contract | Unbounded collection growth exhausts storage |

--- a/docs/vulnerabilities.md
+++ b/docs/vulnerabilities.md
@@ -1416,6 +1416,51 @@ unbiased randomness with an on-chain verifiable proof.
 
 ---
 
+## 34. Stale Pending Admin (`stale_pending_admin`)
+
+**Contract:** `vulnerable/stale_pending_admin` → `vulnerable/stale_pending_admin/src/secure.rs`
+**Severity:** High
+
+### What it is
+
+A two-step admin transfer contract where `cancel_admin_transfer()` emits an event
+but never removes the `PendingAdmin` from persistent storage. The previously
+proposed address can still call `accept_admin()` and take over ownership even
+after cancellation.
+
+### Vulnerable pattern
+
+```rust
+pub fn cancel_admin_transfer(env: Env) {
+    let current: Address = env.storage().persistent().get(&DataKey::Admin).expect("not initialized");
+    current.require_auth();
+    // ❌ Missing: env.storage().persistent().remove(&DataKey::PendingAdmin);
+    env.events().publish((symbol_short!("cancel"),), (current,));
+}
+```
+
+### Secure fix
+
+```rust
+pub fn cancel_admin_transfer(env: Env) {
+    let current: Address = env.storage().persistent().get(&SecureDataKey::Admin).expect("not initialized");
+    current.require_auth();
+    // ✅ Actually remove the pending admin — cancellation is real.
+    env.storage().persistent().remove(&SecureDataKey::PendingAdmin);
+    env.events().publish((symbol_short!("cancel"),), (current,));
+}
+```
+
+Additionally, the secure version uses a transfer nonce so that each proposal
+creates a unique acceptance window, preventing replay of stale proposals.
+
+### Impact
+
+Privilege escalation: a cancelled pending admin can unexpectedly take over the
+contract, gaining access to all admin-gated functions.
+
+---
+
 ## General Soroban Security Checklist
 
 | Check | Description |

--- a/docs/vulnerabilities.md
+++ b/docs/vulnerabilities.md
@@ -1461,6 +1461,49 @@ contract, gaining access to all admin-gated functions.
 
 ---
 
+## 35. Missing `accept_admin` Auth (`accept_admin_missing_auth`)
+
+**Contract:** `vulnerable/accept_admin_missing_auth` → `vulnerable/accept_admin_missing_auth/src/secure.rs`
+**Severity:** Critical
+
+### What it is
+
+A two-step admin transfer contract where `accept_admin()` reads the pending
+admin from storage and promotes them — but **never calls `require_auth()`**.
+Any address can finalise the transfer without the pending admin's knowledge
+or consent, enabling an attacker to seize admin privileges.
+
+### Vulnerable pattern
+
+```rust
+pub fn accept_admin(env: Env) {
+    let pending: Address = env.storage().persistent().get(&DataKey::PendingAdmin).expect("no pending admin");
+    // ❌ Missing: pending.require_auth();
+    env.storage().persistent().set(&DataKey::Admin, &pending);
+    env.storage().persistent().remove(&DataKey::PendingAdmin);
+}
+```
+
+### Secure fix
+
+```rust
+pub fn accept_admin(env: Env) {
+    let pending: Address = env.storage().persistent().get(&SecureDataKey::PendingAdmin).expect("no pending admin");
+    // ✅ Require the pending admin to sign before promoting them.
+    pending.require_auth();
+    env.storage().persistent().set(&SecureDataKey::Admin, &pending);
+    env.storage().persistent().remove(&SecureDataKey::PendingAdmin);
+}
+```
+
+### Impact
+
+Privilege escalation: a random caller can finalise a pending admin transfer
+without the pending address's authorisation, gaining full admin control over
+the contract.
+
+---
+
 ## General Soroban Security Checklist
 
 | Check | Description |

--- a/vulnerable/accept_admin_missing_auth/Cargo.toml
+++ b/vulnerable/accept_admin_missing_auth/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "accept-admin-missing-auth"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating accept_admin missing pending admin auth"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/accept_admin_missing_auth/README.md
+++ b/vulnerable/accept_admin_missing_auth/README.md
@@ -1,0 +1,45 @@
+# `vulnerable/accept_admin_missing_auth`
+
+## Vulnerability: Missing `require_auth` in `accept_admin`
+
+**Severity:** Critical
+
+## Description
+
+A two-step admin transfer contract where `accept_admin()` reads the pending admin from storage and writes them as the new admin — but **never calls `pending.require_auth()`**. Any address can call `accept_admin()` and seize control of the contract.
+
+## Exploit Scenario
+
+1. Admin proposes a new admin via `propose_admin(new_admin)`.
+2. Before the intended pending admin can accept, a random attacker calls `accept_admin()`.
+3. The attacker takes over as admin — the intended target never signed or authorised the transfer.
+
+## Vulnerable Code
+
+```rust
+pub fn accept_admin(env: Env) {
+    let pending: Address = env.storage().persistent().get(&DataKey::PendingAdmin).expect("no pending admin");
+    // ❌ Missing: pending.require_auth();
+    env.storage().persistent().set(&DataKey::Admin, &pending);
+    env.storage().persistent().remove(&DataKey::PendingAdmin);
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn accept_admin(env: Env) {
+    let pending: Address = env.storage().persistent().get(&SecureDataKey::PendingAdmin).expect("no pending admin");
+    // ✅ Require the pending admin to authorise the transfer.
+    pending.require_auth();
+    env.storage().persistent().set(&SecureDataKey::Admin, &pending);
+    env.storage().persistent().remove(&SecureDataKey::PendingAdmin);
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/accept_admin_missing_auth/src/lib.rs
+++ b/vulnerable/accept_admin_missing_auth/src/lib.rs
@@ -1,0 +1,249 @@
+//! VULNERABLE: Missing `require_auth` in `accept_admin`
+//!
+//! A two-step admin transfer contract where `accept_admin()` reads the pending
+//! admin from storage and writes them as the new admin — but **never calls
+//! `pending.require_auth()`**. Any address can call `accept_admin()` and seize
+//! control of the contract.
+//!
+//! VULNERABILITY: The pending admin never signs the acceptance — anyone can
+//! finalise the transfer and take over admin privileges.
+//!
+//! SECURE MIRROR: `secure::SecureAdmin` calls `pending.require_auth()` before
+//! promoting the pending address.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    PendingAdmin,
+}
+
+#[contract]
+pub struct VulnerableAdmin;
+
+#[contractimpl]
+impl VulnerableAdmin {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Propose a new admin. Only the current admin may call this.
+    pub fn propose_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        env.events()
+            .publish((symbol_short!("proposed"),), (new_admin,));
+    }
+
+    /// Cancel a pending transfer. Only the current admin may call this.
+    pub fn cancel_admin_transfer(env: Env) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+        env.events()
+            .publish((symbol_short!("cancel"),), (current,));
+    }
+
+    /// VULNERABLE: reads `PendingAdmin` and promotes them without requiring
+    /// their authorisation. Any caller can seize admin ownership.
+    ///
+    /// # Vulnerability
+    /// Missing `pending.require_auth()`.
+    /// Impact: anyone can call this function and make themselves (or any
+    /// pending address) the admin.
+    pub fn accept_admin(env: Env) {
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .expect("no pending admin");
+        // ❌ BUG: no require_auth on pending — any caller can finalise.
+        env.storage().persistent().set(&DataKey::Admin, &pending);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::PendingAdmin)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, MockAuth, MockAuthInvoke},
+        Address, Env, IntoVal,
+    };
+
+    fn setup_env() -> (Env, Address) {
+        let env = Env::default();
+        let id = env.register_contract(None, VulnerableAdmin);
+        let admin = Address::generate(&env);
+        // initialize does not call require_auth, so no mock needed.
+        VulnerableAdminClient::new(&env, &id).initialize(&admin);
+        (env, id)
+    }
+
+    /// Helper to auth only the current admin for proposals.
+    fn auth_admin(env: &Env, contract_id: &Address, admin: &Address) {
+        env.mock_auths(&[MockAuth {
+            address: admin,
+            invoke: &MockAuthInvoke {
+                contract: contract_id,
+                fn_name: "propose_admin",
+                args: (Address::generate(env),).into_val(env),
+                sub_invokes: &[],
+            },
+        }]);
+    }
+
+    /// Demonstrates the vulnerability: a random caller can call accept_admin
+    /// and the pending address becomes admin without ever signing.
+    #[test]
+    fn test_anyone_can_finalise_transfer() {
+        let (env, id) = setup_env();
+        let client = VulnerableAdminClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let pending = Address::generate(&env);
+        let random_caller = Address::generate(&env);
+
+        // Admin proposes a new pending admin.
+        auth_admin(&env, &id, &admin);
+        client.propose_admin(&pending);
+        assert_eq!(client.get_pending_admin(), Some(pending.clone()));
+
+        // Random caller (not the pending admin) calls accept_admin.
+        // No auth is needed because accept_admin never calls require_auth.
+        // Prove it by NOT mocking any auth for pending or caller.
+        client.accept_admin();
+
+        // The pending address became admin — even though they never signed.
+        assert_eq!(
+            client.get_admin(),
+            pending,
+            "pending admin became admin without their authorisation"
+        );
+    }
+
+    /// Boundary: without a proposal, accept_admin must panic.
+    #[test]
+    #[should_panic(expected = "no pending admin")]
+    fn test_accept_without_proposal_panics() {
+        let (env, id) = setup_env();
+        let client = VulnerableAdminClient::new(&env, &id);
+        client.accept_admin();
+    }
+
+    /// Secure version: accept_admin requires pending admin auth, so an
+    /// attacker without the pending admin's signature is rejected.
+    #[test]
+    fn test_secure_rejects_caller_without_pending_auth() {
+        use crate::secure::SecureAdminClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureAdmin);
+        let client = SecureAdminClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let pending = Address::generate(&env);
+        let attacker = Address::generate(&env);
+
+        // Only admin + attacker auths — pending has NOT authorised.
+        env.mock_auths(&[
+            MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &id,
+                    fn_name: "initialize",
+                    args: (admin.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            },
+            MockAuth {
+                address: &admin,
+                invoke: &MockAuthInvoke {
+                    contract: &id,
+                    fn_name: "propose_admin",
+                    args: (pending.clone(),).into_val(&env),
+                    sub_invokes: &[],
+                },
+            },
+            MockAuth {
+                address: &attacker,
+                invoke: &MockAuthInvoke {
+                    contract: &id,
+                    fn_name: "accept_admin",
+                    args: ().into_val(&env),
+                    sub_invokes: &[],
+                },
+            },
+        ]);
+
+        client.initialize(&admin);
+        client.propose_admin(&pending);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            client.accept_admin();
+        }));
+
+        assert!(
+            result.is_err(),
+            "must reject when pending admin has not signed"
+        );
+        assert_eq!(client.get_admin(), admin, "admin must remain unchanged");
+        assert_eq!(
+            client.get_pending_admin(),
+            Some(pending),
+            "pending admin must remain intact"
+        );
+    }
+
+    /// Secure version: pending admin can accept when they sign.
+    #[test]
+    fn test_secure_pending_admin_can_accept() {
+        use crate::secure::SecureAdminClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureAdmin);
+        let client = SecureAdminClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let pending = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.propose_admin(&pending);
+
+        // Pending admin signs and accepts.
+        client.accept_admin();
+        assert_eq!(
+            client.get_admin(),
+            pending,
+            "pending admin must be able to accept when authorised"
+        );
+    }
+}

--- a/vulnerable/accept_admin_missing_auth/src/secure.rs
+++ b/vulnerable/accept_admin_missing_auth/src/secure.rs
@@ -1,0 +1,75 @@
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+#[contracttype]
+pub enum SecureDataKey {
+    Admin,
+    PendingAdmin,
+}
+
+#[contract]
+pub struct SecureAdmin;
+
+#[contractimpl]
+impl SecureAdmin {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&SecureDataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&SecureDataKey::Admin, &admin);
+    }
+
+    /// Propose a new admin. Only the current admin may call this.
+    pub fn propose_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::PendingAdmin, &new_admin);
+        env.events()
+            .publish((symbol_short!("proposed"),), (new_admin,));
+    }
+
+    /// Cancel a pending transfer. Only the current admin may call this.
+    pub fn cancel_admin_transfer(env: Env) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+        env.storage().persistent().remove(&SecureDataKey::PendingAdmin);
+        env.events()
+            .publish((symbol_short!("cancel"),), (current,));
+    }
+
+    /// SECURE: require the pending admin to authorise the transfer before
+    /// promoting them.
+    pub fn accept_admin(env: Env) {
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::PendingAdmin)
+            .expect("no pending admin");
+        // ✅ Require the pending admin to sign the acceptance.
+        pending.require_auth();
+        env.storage().persistent().set(&SecureDataKey::Admin, &pending);
+        env.storage()
+            .persistent()
+            .remove(&SecureDataKey::PendingAdmin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&SecureDataKey::Admin)
+            .expect("not initialized")
+    }
+
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&SecureDataKey::PendingAdmin)
+    }
+}

--- a/vulnerable/stale_pending_admin/Cargo.toml
+++ b/vulnerable/stale_pending_admin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "stale-pending-admin"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating stale pending admin after cancellation"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/stale_pending_admin/README.md
+++ b/vulnerable/stale_pending_admin/README.md
@@ -1,0 +1,45 @@
+# `vulnerable/stale_pending_admin`
+
+## Vulnerability: Stale Pending Admin (Cancellation Does Not Clear Storage)
+
+**Severity:** High
+
+## Description
+
+A two-step admin transfer contract where `cancel_admin_transfer()` only emits an event but never removes the `PendingAdmin` from persistent storage. The previously proposed address can still call `accept_admin()` and take over ownership after cancellation.
+
+## Exploit Scenario
+
+1. Admin proposes a new admin via `propose_admin(new_admin)`.
+2. Admin changes their mind and calls `cancel_admin_transfer()`.
+3. The proposed address calls `accept_admin()` and takes over ownership — even though the transfer was cancelled.
+
+## Vulnerable Code
+
+```rust
+pub fn cancel_admin_transfer(env: Env) {
+    let current: Address = env.storage().persistent().get(&DataKey::Admin).expect("not initialized");
+    current.require_auth();
+    // ❌ Missing: env.storage().persistent().remove(&DataKey::PendingAdmin);
+    env.events().publish((symbol_short!("cancel"),), (current,));
+}
+```
+
+## Secure Fix
+
+```rust
+pub fn cancel_admin_transfer(env: Env) {
+    let current: Address = env.storage().persistent().get(&SecureDataKey::Admin).expect("not initialized");
+    current.require_auth();
+    // ✅ Actually remove the pending admin — cancellation is real.
+    env.storage().persistent().remove(&SecureDataKey::PendingAdmin);
+    env.events().publish((symbol_short!("cancel"),), (current,));
+}
+```
+
+See the inline `secure.rs` module inside this crate for the full corrected implementation.
+
+## References
+
+- [docs/vulnerabilities.md](../../docs/vulnerabilities.md)
+- [docs/threat_model.md](../../docs/threat_model.md)

--- a/vulnerable/stale_pending_admin/src/lib.rs
+++ b/vulnerable/stale_pending_admin/src/lib.rs
@@ -1,0 +1,221 @@
+//! VULNERABLE: Stale Pending Admin After Cancellation
+//!
+//! A two-step admin transfer stores a `PendingAdmin` key in persistent storage.
+//! When the current admin cancels the transfer, the contract only emits an event
+//! but **does not remove** the `PendingAdmin` key from storage.
+//!
+//! VULNERABILITY: After cancellation the pending address is still present in
+//! storage and can call `accept_admin` to seize ownership unexpectedly.
+//!
+//! SECURE MIRROR: `secure::SecureAdmin` removes the `PendingAdmin` key during
+//! cancellation so the proposal is truly invalidated.
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+pub mod secure;
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    PendingAdmin,
+}
+
+#[contract]
+pub struct VulnerableAdmin;
+
+#[contractimpl]
+impl VulnerableAdmin {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Propose a new admin. Only the current admin may call this.
+    pub fn propose_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::PendingAdmin, &new_admin);
+        env.events()
+            .publish((symbol_short!("proposed"),), (new_admin,));
+    }
+
+    /// VULNERABLE: emits a cancellation event but leaves `PendingAdmin` in
+    /// storage. The pending address can still call `accept_admin` afterwards.
+    ///
+    /// # Vulnerability
+    /// Missing `env.storage().persistent().remove(&DataKey::PendingAdmin)`.
+    /// Impact: a cancelled pending admin can silently accept ownership later.
+    pub fn cancel_admin_transfer(env: Env) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+        // ❌ BUG: only emits an event — PendingAdmin key is NOT removed.
+        env.events()
+            .publish((symbol_short!("cancel"),), (current,));
+    }
+
+    /// Accept admin ownership. Reads `PendingAdmin` from storage — which is
+    /// still present after a buggy cancellation.
+    pub fn accept_admin(env: Env) {
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::PendingAdmin)
+            .expect("no pending admin");
+        pending.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &pending);
+        env.storage().persistent().remove(&DataKey::PendingAdmin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized")
+    }
+
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::PendingAdmin)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup() -> (Env, VulnerableAdminClient<'static>, Address) {
+        let env = Env::default();
+        let id = env.register_contract(None, VulnerableAdmin);
+        let client = VulnerableAdminClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        env.mock_all_auths();
+        client.initialize(&admin);
+        (env, client, admin)
+    }
+
+    /// Demonstrates the vulnerability: after cancellation the pending admin
+    /// can still call accept_admin and seize ownership.
+    #[test]
+    fn test_stale_pending_admin_accepts_after_cancellation() {
+        let (env, client, admin) = setup();
+        let pending = Address::generate(&env);
+
+        // Step 1: propose a new admin.
+        client.propose_admin(&pending);
+        assert_eq!(client.get_pending_admin(), Some(pending.clone()));
+
+        // Step 2: current admin cancels the transfer.
+        client.cancel_admin_transfer();
+
+        // BUG: pending admin is still in storage after cancellation.
+        assert_eq!(
+            client.get_pending_admin(),
+            Some(pending.clone()),
+            "pending admin should have been cleared but was not"
+        );
+
+        // Step 3: the stale pending admin accepts — ownership is stolen.
+        client.accept_admin();
+        assert_eq!(
+            client.get_admin(),
+            pending,
+            "stale pending admin seized ownership after cancellation"
+        );
+    }
+
+    /// Boundary: without a proposal, accept_admin must panic.
+    #[test]
+    #[should_panic(expected = "no pending admin")]
+    fn test_accept_without_proposal_panics() {
+        let (_env, client, _admin) = setup();
+        client.accept_admin();
+    }
+
+    /// Secure version: propose_admin stores a nonce; accept_admin requires it.
+    /// Happy path — correct nonce succeeds.
+    #[test]
+    fn test_secure_accept_with_correct_nonce_succeeds() {
+        use crate::secure::SecureAdminClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureAdmin);
+        let client = SecureAdminClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let pending = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.propose_admin(&pending);
+
+        // First proposal gets nonce = 1.
+        client.accept_admin(&1);
+        assert_eq!(
+            client.get_admin(),
+            pending,
+            "secure accept with correct nonce must transfer ownership"
+        );
+    }
+
+    /// Secure version: cancellation removes the pending admin key so
+    /// accept_admin panics when called afterwards.
+    #[test]
+    #[should_panic(expected = "no pending admin")]
+    fn test_secure_rejects_stale_accept_after_cancellation() {
+        use crate::secure::SecureAdminClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureAdmin);
+        let client = SecureAdminClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let pending = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.propose_admin(&pending);
+
+        // Secure cancel removes the key.
+        client.cancel_admin_transfer();
+        assert_eq!(
+            client.get_pending_admin(),
+            None,
+            "secure cancel must clear pending admin"
+        );
+
+        // This must panic — no pending admin in storage.
+        client.accept_admin(&1);
+    }
+
+    /// Secure version: wrong nonce must be rejected.
+    #[test]
+    #[should_panic(expected = "nonce mismatch")]
+    fn test_secure_rejects_wrong_nonce() {
+        use crate::secure::SecureAdminClient;
+
+        let env = Env::default();
+        let id = env.register_contract(None, secure::SecureAdmin);
+        let client = SecureAdminClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let pending = Address::generate(&env);
+
+        env.mock_all_auths();
+        client.initialize(&admin);
+        client.propose_admin(&pending);
+
+        // Proposal nonce is 1, but we pass 99.
+        client.accept_admin(&99);
+    }
+}

--- a/vulnerable/stale_pending_admin/src/secure.rs
+++ b/vulnerable/stale_pending_admin/src/secure.rs
@@ -1,0 +1,114 @@
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+#[contracttype]
+pub enum SecureDataKey {
+    Admin,
+    PendingAdmin,
+    PendingAdminNonce,
+    AdminNonce,
+}
+
+#[contract]
+pub struct SecureAdmin;
+
+#[contractimpl]
+impl SecureAdmin {
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&SecureDataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().persistent().set(&SecureDataKey::Admin, &admin);
+        // ✅ Initialise nonce counter to prevent stale acceptance replay.
+        env.storage().persistent().set(&SecureDataKey::AdminNonce, &0u32);
+    }
+
+    /// Propose a new admin. Increments the transfer nonce and stores it
+    /// alongside the pending admin so each proposal creates a unique
+    /// acceptance window.
+    pub fn propose_admin(env: Env, new_admin: Address) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+
+        let nonce: u32 = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::AdminNonce)
+            .unwrap_or(0);
+        let next_nonce = nonce + 1;
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::AdminNonce, &next_nonce);
+
+        // ✅ Store the nonce that must be presented by the pending admin.
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::PendingAdminNonce, &next_nonce);
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::PendingAdmin, &new_admin);
+    }
+
+    /// SECURE: remove the pending admin key on cancellation so the proposal
+    /// is truly invalidated.
+    pub fn cancel_admin_transfer(env: Env) {
+        let current: Address = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::Admin)
+            .expect("not initialized");
+        current.require_auth();
+        // ✅ Actually remove the pending admin — cancellation is real.
+        env.storage().persistent().remove(&SecureDataKey::PendingAdmin);
+        env.storage()
+            .persistent()
+            .remove(&SecureDataKey::PendingAdminNonce);
+        env.events().publish((symbol_short!("cancel"),), (current,));
+    }
+
+    /// Accept admin ownership. Requires the pending address auth and
+    /// a matching nonce that was assigned at proposal time.
+    /// The nonce ensures that even if the pending admin key survives
+    /// (e.g. from a stale cancellation), a mismatched nonce will block the
+    /// acceptance.
+    pub fn accept_admin(env: Env, nonce: u32) {
+        let pending: Address = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::PendingAdmin)
+            .expect("no pending admin");
+        pending.require_auth();
+
+        // ✅ Verify the nonce matches the proposal.
+        let expected: u32 = env
+            .storage()
+            .persistent()
+            .get(&SecureDataKey::PendingAdminNonce)
+            .expect("no pending nonce");
+        if nonce != expected {
+            panic!("nonce mismatch");
+        }
+
+        env.storage().persistent().set(&SecureDataKey::Admin, &pending);
+        env.storage()
+            .persistent()
+            .remove(&SecureDataKey::PendingAdmin);
+        env.storage()
+            .persistent()
+            .remove(&SecureDataKey::PendingAdminNonce);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&SecureDataKey::Admin)
+            .expect("not initialized")
+    }
+
+    pub fn get_pending_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&SecureDataKey::PendingAdmin)
+    }
+}


### PR DESCRIPTION
## Summary

Implements `vulnerable/accept_admin_missing_auth` — a two-step admin transfer contract where `accept_admin()` reads the pending admin from storage and promotes them **without calling `require_auth()`**. Any caller can finalise the transfer and take over admin privileges.

Closes #226

## Vulnerable pattern

```rust
pub fn accept_admin(env: Env) {
    let pending: Address = env.storage().persistent().get(&DataKey::PendingAdmin).expect("no pending admin");
    // BUG: Missing pending.require_auth();
    env.storage().persistent().set(&DataKey::Admin, &pending);
    env.storage().persistent().remove(&DataKey::PendingAdmin);
}
```

## Secure fix

```rust
pub fn accept_admin(env: Env) {
    let pending: Address = env.storage().persistent().get(&SecureDataKey::PendingAdmin).expect("no pending admin");
    pending.require_auth();  // the fix
    env.storage().persistent().set(&SecureDataKey::Admin, &pending);
    env.storage().persistent().remove(&SecureDataKey::PendingAdmin);
}
```

## Tests

| Test | Type |
|---|---|
| `test_anyone_can_finalise_transfer` | Vulnerable path succeeds (random caller accepts without pending auth) |
| `test_accept_without_proposal_panics` | Boundary: reject with no proposal |
| `test_secure_rejects_caller_without_pending_auth` | Secure rejects random caller |
| `test_secure_pending_admin_can_accept` | Secure happy path |

## Files changed
- `Cargo.toml` — workspace member registration
- `vulnerable/accept_admin_missing_auth/` — new crate
- `README.md` — table entry
- `docs/vulnerabilities.md` — vulnerability documentation
