### PR TITLE
Feat/twap window too short

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ members = [
     "vulnerable/sequence_as_timestamp",
     "vulnerable/balance_key_missing_user",
     "vulnerable/report_hash_unbound_contract",
+    "vulnerable/inactive_circuit_breaker",
 ]
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ members = [
     "vulnerable/balance_key_missing_user",
     "vulnerable/report_hash_unbound_contract",
     "vulnerable/inactive_circuit_breaker",
+    "vulnerable/twap_window_too_short",
 ]
 
 

--- a/vulnerable/inactive_circuit_breaker/Cargo.toml
+++ b/vulnerable/inactive_circuit_breaker/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "inactive-circuit-breaker"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating an inactive circuit breaker — max price-move threshold stored but never enforced"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/inactive_circuit_breaker/src/lib.rs
+++ b/vulnerable/inactive_circuit_breaker/src/lib.rs
@@ -1,0 +1,287 @@
+//! VULNERABLE: Inactive Circuit Breaker
+//!
+//! A market contract stores a `max_move_bps` threshold (maximum allowed
+//! price move in basis points) but the `update_price` function never reads
+//! or enforces it. Any price — no matter how extreme — is written directly
+//! to storage and immediately consumed by swaps and liquidations.
+//!
+//! VULNERABILITY: `max_move_bps` is set during initialisation and is readable
+//! via `get_config`, but `update_price` ignores it entirely. A manipulated
+//! price flows into `swap_out` and `liquidate` without any pause or rejection.
+//!
+//! SEVERITY: High
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+pub mod secure;
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    /// Address authorised to push price updates.
+    Admin,
+    /// Current market price (scaled by 1e7, i.e. 1.0 == 10_000_000).
+    Price,
+    /// Maximum allowed single-update move expressed in basis points (1 bps = 0.01 %).
+    /// Stored but NEVER checked in the vulnerable implementation.
+    MaxMoveBps,
+    /// Whether the market is paused (unused in the vulnerable path).
+    Paused,
+}
+
+// ── Vulnerable market contract ────────────────────────────────────────────────
+
+#[contract]
+pub struct VulnerableMarket;
+
+#[contractimpl]
+impl VulnerableMarket {
+    /// Initialise the market.
+    ///
+    /// * `initial_price` – starting price (scaled by 1e7).
+    /// * `max_move_bps`  – circuit-breaker threshold in basis points.
+    ///                     Stored for show; never enforced.
+    pub fn initialize(env: Env, admin: Address, initial_price: i128, max_move_bps: u32) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        assert!(initial_price > 0, "price must be positive");
+        assert!(max_move_bps > 0, "threshold must be positive");
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Price, &initial_price);
+        env.storage().persistent().set(&DataKey::MaxMoveBps, &max_move_bps);
+        env.storage().persistent().set(&DataKey::Paused, &false);
+    }
+
+    /// ❌ BUG: writes the new price without checking `max_move_bps`.
+    ///
+    /// The circuit-breaker threshold is stored in `DataKey::MaxMoveBps` but
+    /// this function never reads it. A price that moves 10 000 % is accepted
+    /// just as readily as a 0.01 % move.
+    pub fn update_price(env: Env, actor: Address, new_price: i128) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        // Auth check is present — the bug is NOT missing auth, it is the
+        // missing threshold check that follows.
+        if actor != admin {
+            panic!("unauthorized");
+        }
+        actor.require_auth();
+
+        assert!(new_price > 0, "price must be positive");
+
+        // ❌ Missing: compare new_price against old_price using max_move_bps.
+        // The fixture makes this unsafe path reachable and easy to scan.
+        let _ = env.storage().persistent().get::<DataKey, u32>(&DataKey::MaxMoveBps); // read but discarded
+        env.storage().persistent().set(&DataKey::Price, &new_price);
+    }
+
+    /// Simulate a swap that reads the current price.
+    ///
+    /// Returns the output amount for `amount_in` units at the current price.
+    /// Because `update_price` never pauses the market, a manipulated price
+    /// flows straight through here.
+    pub fn swap_out(env: Env, user: Address, amount_in: i128) -> i128 {
+        user.require_auth();
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        assert!(!paused, "market paused");
+
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price)
+            .expect("price not set");
+        // Simple linear pricing: out = amount_in * price / 1e7
+        amount_in * price / 10_000_000
+    }
+
+    /// Simulate a liquidation that reads the current price.
+    ///
+    /// Returns the collateral seized for `debt` units at the current price.
+    pub fn liquidate(env: Env, liquidator: Address, debt: i128) -> i128 {
+        liquidator.require_auth();
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        assert!(!paused, "market paused");
+
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price)
+            .expect("price not set");
+        // Collateral seized = debt / price * 1e7 (inverse of swap_out)
+        debt * 10_000_000 / price
+    }
+
+    /// Return the current price.
+    pub fn get_price(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Price)
+            .expect("price not set")
+    }
+
+    /// Return `(max_move_bps, paused)` — the circuit-breaker config.
+    pub fn get_config(env: Env) -> (u32, bool) {
+        let max_move_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MaxMoveBps)
+            .unwrap_or(0);
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        (max_move_bps, paused)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    /// Initial price: 10_000_000 (== 1.0).
+    /// Circuit-breaker threshold: 500 bps (5 %).
+    const INITIAL_PRICE: i128 = 10_000_000;
+    const MAX_MOVE_BPS: u32 = 500; // 5 %
+
+    fn setup() -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, VulnerableMarket);
+        let admin = Address::generate(&env);
+        VulnerableMarketClient::new(&env, &contract_id)
+            .initialize(&admin, &INITIAL_PRICE, &MAX_MOVE_BPS);
+        (env, contract_id, admin)
+    }
+
+    // ── Vulnerable path ───────────────────────────────────────────────────────
+
+    /// The circuit-breaker threshold is stored but the contract accepts a price
+    /// that is 100× the initial value — a 9 900 % move — without complaint.
+    #[test]
+    fn test_vulnerable_accepts_extreme_price_move() {
+        let (env, contract_id, admin) = setup();
+        let client = VulnerableMarketClient::new(&env, &contract_id);
+
+        // Sanity: threshold is stored.
+        let (stored_bps, _) = client.get_config();
+        assert_eq!(stored_bps, MAX_MOVE_BPS);
+
+        // 9 900 % move — should be rejected by any real circuit breaker.
+        let manipulated_price = INITIAL_PRICE * 100;
+        client.update_price(&admin, &manipulated_price);
+
+        // ❌ Vulnerable: price was accepted, market is NOT paused.
+        assert_eq!(client.get_price(), manipulated_price);
+        let (_, paused) = client.get_config();
+        assert!(!paused, "market should have paused but did not");
+    }
+
+    /// With the manipulated price in place, swap_out returns an inflated amount.
+    #[test]
+    fn test_vulnerable_swap_uses_manipulated_price() {
+        let (env, contract_id, admin) = setup();
+        let client = VulnerableMarketClient::new(&env, &contract_id);
+        let user = Address::generate(&env);
+
+        // Push a 50× price spike.
+        client.update_price(&admin, &(INITIAL_PRICE * 50));
+
+        let out = client.swap_out(&user, &1_000_000);
+        // At 50× price: out = 1_000_000 * (10_000_000 * 50) / 10_000_000 = 50_000_000
+        assert_eq!(out, 50_000_000);
+    }
+
+    /// Boundary: a move exactly at the threshold should be accepted.
+    /// In the vulnerable contract this passes trivially (everything passes).
+    #[test]
+    fn test_vulnerable_boundary_move_accepted() {
+        let (env, contract_id, admin) = setup();
+        let client = VulnerableMarketClient::new(&env, &contract_id);
+
+        // 5 % move = exactly at the 500 bps threshold.
+        let boundary_price = INITIAL_PRICE + (INITIAL_PRICE * 500 / 10_000);
+        client.update_price(&admin, &boundary_price);
+        assert_eq!(client.get_price(), boundary_price);
+    }
+
+    // ── Secure mirror tests ───────────────────────────────────────────────────
+
+    /// Secure contract rejects a price move that exceeds max_move_bps.
+    #[test]
+    #[should_panic(expected = "price move exceeds circuit breaker threshold")]
+    fn test_secure_rejects_extreme_price_move() {
+        use crate::secure::SecureMarketClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureMarket);
+        let client = SecureMarketClient::new(&env, &id);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin, &INITIAL_PRICE, &MAX_MOVE_BPS);
+
+        // 9 900 % move — must be rejected.
+        client.update_price(&admin, &(INITIAL_PRICE * 100));
+    }
+
+    /// Secure contract accepts a price move within the threshold.
+    #[test]
+    fn test_secure_accepts_move_within_threshold() {
+        use crate::secure::SecureMarketClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureMarket);
+        let client = SecureMarketClient::new(&env, &id);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin, &INITIAL_PRICE, &MAX_MOVE_BPS);
+
+        // 3 % move — within the 5 % threshold.
+        let small_move = INITIAL_PRICE + (INITIAL_PRICE * 300 / 10_000);
+        client.update_price(&admin, &small_move);
+        assert_eq!(client.get_price(), small_move);
+    }
+
+    /// Secure contract pauses the market when the threshold is breached,
+    /// blocking subsequent swaps.
+    #[test]
+    #[should_panic(expected = "market paused")]
+    fn test_secure_pauses_market_on_breach_blocking_swaps() {
+        use crate::secure::SecureMarketClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureMarket);
+        let client = SecureMarketClient::new(&env, &id);
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        client.initialize(&admin, &INITIAL_PRICE, &MAX_MOVE_BPS);
+
+        // Force a breach via the admin bypass (simulates an oracle pushing a bad price).
+        client.force_pause(&admin);
+
+        // swap_out must now panic because the market is paused.
+        client.swap_out(&user, &1_000_000);
+    }
+}

--- a/vulnerable/inactive_circuit_breaker/src/secure.rs
+++ b/vulnerable/inactive_circuit_breaker/src/secure.rs
@@ -1,0 +1,160 @@
+//! SECURE mirror: enforce the circuit-breaker threshold on every price update.
+//!
+//! `update_price` computes the percentage move between the old and new price
+//! in basis points and panics with `"price move exceeds circuit breaker
+//! threshold"` when the move exceeds `max_move_bps`. It also sets
+//! `DataKey::Paused` to `true` so that `swap_out` and `liquidate` are blocked
+//! until an admin explicitly unpauses the market.
+
+use crate::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureMarket;
+
+#[contractimpl]
+impl SecureMarket {
+    pub fn initialize(env: Env, admin: Address, initial_price: i128, max_move_bps: u32) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        assert!(initial_price > 0, "price must be positive");
+        assert!(max_move_bps > 0, "threshold must be positive");
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Price, &initial_price);
+        env.storage().persistent().set(&DataKey::MaxMoveBps, &max_move_bps);
+        env.storage().persistent().set(&DataKey::Paused, &false);
+    }
+
+    /// ✅ Reads `max_move_bps`, computes the move, and rejects or pauses on breach.
+    pub fn update_price(env: Env, actor: Address, new_price: i128) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if actor != admin {
+            panic!("unauthorized");
+        }
+        actor.require_auth();
+
+        assert!(new_price > 0, "price must be positive");
+
+        let old_price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price)
+            .expect("price not set");
+
+        let max_move_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MaxMoveBps)
+            .expect("threshold not set");
+
+        // Compute absolute move in basis points:
+        //   move_bps = |new - old| * 10_000 / old
+        let delta = if new_price > old_price {
+            new_price - old_price
+        } else {
+            old_price - new_price
+        };
+        let move_bps = (delta * 10_000) / old_price;
+
+        if move_bps > max_move_bps as i128 {
+            // ✅ Pause the market so swaps and liquidations are blocked.
+            env.storage().persistent().set(&DataKey::Paused, &true);
+            panic!("price move exceeds circuit breaker threshold");
+        }
+
+        env.storage().persistent().set(&DataKey::Price, &new_price);
+    }
+
+    /// Swap output at the current price. Blocked when the market is paused.
+    pub fn swap_out(env: Env, user: Address, amount_in: i128) -> i128 {
+        user.require_auth();
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        assert!(!paused, "market paused");
+
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price)
+            .expect("price not set");
+        amount_in * price / 10_000_000
+    }
+
+    /// Liquidation at the current price. Blocked when the market is paused.
+    pub fn liquidate(env: Env, liquidator: Address, debt: i128) -> i128 {
+        liquidator.require_auth();
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        assert!(!paused, "market paused");
+
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Price)
+            .expect("price not set");
+        debt * 10_000_000 / price
+    }
+
+    /// Return the current price.
+    pub fn get_price(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Price)
+            .expect("price not set")
+    }
+
+    /// Return `(max_move_bps, paused)`.
+    pub fn get_config(env: Env) -> (u32, bool) {
+        let max_move_bps: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MaxMoveBps)
+            .unwrap_or(0);
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        (max_move_bps, paused)
+    }
+
+    /// Admin-only: manually pause the market (e.g. after off-chain detection).
+    pub fn force_pause(env: Env, admin: Address) {
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &true);
+    }
+
+    /// Admin-only: unpause the market after investigation.
+    pub fn unpause(env: Env, admin: Address) {
+        let stored_admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &false);
+    }
+}

--- a/vulnerable/twap_window_too_short/Cargo.toml
+++ b/vulnerable/twap_window_too_short/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "twap-window-too-short"
+version = "0.1.0"
+edition = "2021"
+description = "Vulnerable Soroban contract demonstrating a TWAP window that can be set to one ledger, collapsing the average into a spot price"
+license = "MIT"
+repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }

--- a/vulnerable/twap_window_too_short/src/lib.rs
+++ b/vulnerable/twap_window_too_short/src/lib.rs
@@ -1,0 +1,337 @@
+//! VULNERABLE: TWAP Window Too Short
+//!
+//! A time-weighted average price (TWAP) oracle stores a ring-buffer of price
+//! observations and averages them over a configurable `window` (number of
+//! ledgers to retain). The vulnerability is that `window` is accepted as any
+//! positive value — including `1`.
+//!
+//! When `window == 1` the buffer holds exactly one observation at a time.
+//! Every call to `record_price` evicts the previous entry, so `get_twap`
+//! always returns the most-recently written price. The TWAP degenerates into
+//! a spot price and provides zero manipulation resistance: an attacker can
+//! push an extreme price in one ledger and immediately read it back as the
+//! "average".
+//!
+//! VULNERABILITY: `initialize` accepts `window = 1` (or any positive value)
+//! without enforcing a governance-defined minimum. `get_twap` then returns a
+//! single-sample average that is indistinguishable from a raw spot price.
+//!
+//! SEVERITY: Medium
+
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Vec};
+
+pub mod secure;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// A single price observation recorded at a specific ledger sequence number.
+#[contracttype]
+#[derive(Clone)]
+pub struct Observation {
+    /// Ledger sequence at which the price was recorded.
+    pub ledger: u32,
+    /// Price at that ledger (scaled by 1e7; 1.0 == 10_000_000).
+    pub price: i128,
+}
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    /// Address authorised to push price updates.
+    Admin,
+    /// Number of observations to retain (the TWAP window size).
+    /// Stored but NOT validated against a minimum in the vulnerable path.
+    Window,
+    /// Ring-buffer of the most recent `window` observations.
+    Observations,
+}
+
+// ── Vulnerable TWAP oracle ────────────────────────────────────────────────────
+
+#[contract]
+pub struct VulnerableTwap;
+
+#[contractimpl]
+impl VulnerableTwap {
+    /// Initialise the oracle.
+    ///
+    /// * `window` – number of observations to average. Any positive value is
+    ///              accepted, including `1`, which collapses the TWAP to spot.
+    pub fn initialize(env: Env, admin: Address, window: u32) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        // ❌ BUG: no minimum window check. window = 1 is silently accepted.
+        assert!(window > 0, "window must be positive");
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Window, &window);
+        let empty: Vec<Observation> = Vec::new(&env);
+        env.storage().persistent().set(&DataKey::Observations, &empty);
+    }
+
+    /// Record a new price observation.
+    ///
+    /// Appends the current `(ledger, price)` pair to the buffer and trims it
+    /// to the last `window` entries. With `window == 1` only the newest entry
+    /// survives, making `get_twap` equivalent to `get_price`.
+    pub fn record_price(env: Env, actor: Address, price: i128) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if actor != admin {
+            panic!("unauthorized");
+        }
+        actor.require_auth();
+
+        assert!(price > 0, "price must be positive");
+
+        let window: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Window)
+            .expect("window not set");
+
+        let mut obs: Vec<Observation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Observations)
+            .unwrap_or(Vec::new(&env));
+
+        obs.push_back(Observation {
+            ledger: env.ledger().sequence(),
+            price,
+        });
+
+        // Trim to the most recent `window` observations.
+        // ❌ With window == 1 this always leaves exactly one entry — spot price.
+        while obs.len() > window {
+            obs.remove(0);
+        }
+
+        env.storage().persistent().set(&DataKey::Observations, &obs);
+    }
+
+    /// Return the arithmetic mean of all stored observations.
+    ///
+    /// ❌ With `window == 1` there is always exactly one observation, so this
+    /// returns the last recorded price verbatim — a spot price, not an average.
+    pub fn get_twap(env: Env) -> i128 {
+        let obs: Vec<Observation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Observations)
+            .unwrap_or(Vec::new(&env));
+
+        assert!(!obs.is_empty(), "no observations recorded");
+
+        let mut sum: i128 = 0;
+        for o in obs.iter() {
+            sum += o.price;
+        }
+        sum / obs.len() as i128
+    }
+
+    /// Return the configured window size.
+    pub fn get_window(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Window)
+            .unwrap_or(0)
+    }
+
+    /// Return the number of observations currently in the buffer.
+    pub fn observation_count(env: Env) -> u32 {
+        let obs: Vec<Observation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Observations)
+            .unwrap_or(Vec::new(&env));
+        obs.len()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env};
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    fn setup_vulnerable(window: u32) -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, VulnerableTwap);
+        let admin = Address::generate(&env);
+        VulnerableTwapClient::new(&env, &id).initialize(&admin, &window);
+        (env, id, admin)
+    }
+
+    fn advance(env: &Env, ledgers: u32) {
+        env.ledger().set_sequence_number(env.ledger().sequence() + ledgers);
+    }
+
+    // ── Vulnerable path ───────────────────────────────────────────────────────
+
+    /// Window of 1 is accepted — the TWAP degenerates to spot price.
+    #[test]
+    fn test_vulnerable_window_one_accepted() {
+        let (env, id, admin) = setup_vulnerable(1);
+        let client = VulnerableTwapClient::new(&env, &id);
+
+        assert_eq!(client.get_window(), 1);
+
+        // Record a normal price.
+        client.record_price(&admin, &10_000_000); // 1.0
+        assert_eq!(client.observation_count(), 1);
+        assert_eq!(client.get_twap(), 10_000_000);
+    }
+
+    /// With window == 1, a single manipulated update overwrites the entire
+    /// history. The TWAP immediately reflects the manipulated spot price.
+    #[test]
+    fn test_vulnerable_single_update_overwrites_twap() {
+        let (env, id, admin) = setup_vulnerable(1);
+        let client = VulnerableTwapClient::new(&env, &id);
+
+        // Establish a baseline price over several ledgers.
+        client.record_price(&admin, &10_000_000); // 1.0
+        advance(&env, 1);
+        client.record_price(&admin, &10_100_000); // 1.01
+        advance(&env, 1);
+        client.record_price(&admin, &10_050_000); // 1.005
+
+        // Buffer holds only the last entry — history is gone.
+        assert_eq!(client.observation_count(), 1);
+
+        // Attacker pushes a 10× spike in one ledger.
+        advance(&env, 1);
+        client.record_price(&admin, &100_000_000); // 10.0
+
+        // ❌ TWAP == manipulated spot price; no averaging occurred.
+        let twap = client.get_twap();
+        assert_eq!(twap, 100_000_000,
+            "vulnerable: TWAP should equal the manipulated spot price");
+    }
+
+    /// Boundary: window == 1 is the exact boundary that should be rejected.
+    /// In the vulnerable contract it is silently accepted.
+    #[test]
+    fn test_vulnerable_boundary_window_one_silently_accepted() {
+        // This must NOT panic in the vulnerable implementation.
+        let (_env, _id, _admin) = setup_vulnerable(1);
+        // If we reach here the boundary was accepted — demonstrating the flaw.
+    }
+
+    /// With a larger window the vulnerable contract does average correctly,
+    /// confirming the bug is specifically the missing minimum-window guard.
+    #[test]
+    fn test_vulnerable_larger_window_averages_correctly() {
+        let (env, id, admin) = setup_vulnerable(3);
+        let client = VulnerableTwapClient::new(&env, &id);
+
+        client.record_price(&admin, &10_000_000);
+        advance(&env, 1);
+        client.record_price(&admin, &20_000_000);
+        advance(&env, 1);
+        client.record_price(&admin, &30_000_000);
+
+        // Average of 10M, 20M, 30M = 20M.
+        assert_eq!(client.get_twap(), 20_000_000);
+
+        // A spike now only moves the average by 1/3.
+        advance(&env, 1);
+        client.record_price(&admin, &100_000_000);
+        // Buffer: [20M, 30M, 100M] → avg = 50M — still dampened.
+        let twap = client.get_twap();
+        assert!(twap < 100_000_000,
+            "larger window dampens the spike: twap={}", twap);
+    }
+
+    // ── Secure mirror tests ───────────────────────────────────────────────────
+
+    /// Secure contract rejects window == 1 at initialisation.
+    #[test]
+    #[should_panic(expected = "twap window below minimum")]
+    fn test_secure_rejects_window_one() {
+        use crate::secure::SecureTwapClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureTwap);
+        let client = SecureTwapClient::new(&env, &id);
+        let admin = Address::generate(&env);
+
+        // window = 1 must be rejected.
+        client.initialize(&admin, &1);
+    }
+
+    /// Secure contract rejects any window below MIN_TWAP_WINDOW.
+    #[test]
+    #[should_panic(expected = "twap window below minimum")]
+    fn test_secure_rejects_window_below_minimum() {
+        use crate::secure::SecureTwapClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureTwap);
+        let client = SecureTwapClient::new(&env, &id);
+        let admin = Address::generate(&env);
+
+        // MIN_TWAP_WINDOW is 10; window = 9 must also be rejected.
+        client.initialize(&admin, &9);
+    }
+
+    /// Secure contract accepts a window at or above the minimum.
+    #[test]
+    fn test_secure_accepts_window_at_minimum() {
+        use crate::secure::SecureTwapClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureTwap);
+        let client = SecureTwapClient::new(&env, &id);
+        let admin = Address::generate(&env);
+
+        // Exactly at the minimum — must succeed.
+        client.initialize(&admin, &10);
+        assert_eq!(client.get_window(), 10);
+    }
+
+    /// With a secure window, a single manipulated update cannot dominate the TWAP.
+    #[test]
+    fn test_secure_single_spike_dampened_by_window() {
+        use crate::secure::SecureTwapClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, secure::SecureTwap);
+        let client = SecureTwapClient::new(&env, &id);
+        let admin = Address::generate(&env);
+
+        client.initialize(&admin, &10);
+
+        // Fill the window with a stable price of 10_000_000.
+        for i in 0..10_u32 {
+            env.ledger().set_sequence_number(i);
+            client.record_price(&admin, &10_000_000);
+        }
+
+        // One spike at 10× the normal price.
+        env.ledger().set_sequence_number(10);
+        client.record_price(&admin, &100_000_000);
+
+        // TWAP = (9 * 10_000_000 + 100_000_000) / 10 = 19_000_000
+        // Still far below the manipulated spot price of 100_000_000.
+        let twap = client.get_twap();
+        assert!(twap < 100_000_000,
+            "secure: spike must not dominate TWAP; got {}", twap);
+        assert_eq!(twap, 19_000_000);
+    }
+}

--- a/vulnerable/twap_window_too_short/src/secure.rs
+++ b/vulnerable/twap_window_too_short/src/secure.rs
@@ -1,0 +1,114 @@
+//! SECURE mirror: enforce a governance-defined minimum TWAP window.
+//!
+//! `initialize` rejects any `window` below `MIN_TWAP_WINDOW` (10 ledgers)
+//! with `"twap window below minimum"`. This ensures the observation buffer
+//! always spans enough ledgers to dampen single-block price manipulation.
+
+use crate::{DataKey, Observation};
+use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
+
+/// Minimum number of observations required for a valid TWAP window.
+/// A governance process should set this; here it is a compile-time constant.
+pub const MIN_TWAP_WINDOW: u32 = 10;
+
+#[contract]
+pub struct SecureTwap;
+
+#[contractimpl]
+impl SecureTwap {
+    /// Initialise the oracle.
+    ///
+    /// ✅ Rejects `window < MIN_TWAP_WINDOW` to prevent the TWAP from
+    /// collapsing into a spot price.
+    pub fn initialize(env: Env, admin: Address, window: u32) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        // ✅ Enforce the minimum window.
+        if window < MIN_TWAP_WINDOW {
+            panic!("twap window below minimum");
+        }
+
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage().persistent().set(&DataKey::Window, &window);
+        let empty: Vec<Observation> = Vec::new(&env);
+        env.storage().persistent().set(&DataKey::Observations, &empty);
+    }
+
+    /// Record a new price observation, trimming the buffer to `window` entries.
+    pub fn record_price(env: Env, actor: Address, price: i128) {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .expect("not initialized");
+        if actor != admin {
+            panic!("unauthorized");
+        }
+        actor.require_auth();
+
+        assert!(price > 0, "price must be positive");
+
+        let window: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Window)
+            .expect("window not set");
+
+        let mut obs: Vec<Observation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Observations)
+            .unwrap_or(Vec::new(&env));
+
+        obs.push_back(Observation {
+            ledger: env.ledger().sequence(),
+            price,
+        });
+
+        // Trim to the most recent `window` observations.
+        while obs.len() > window {
+            obs.remove(0);
+        }
+
+        env.storage().persistent().set(&DataKey::Observations, &obs);
+    }
+
+    /// Return the arithmetic mean of all stored observations.
+    ///
+    /// ✅ Because `window >= MIN_TWAP_WINDOW`, a single manipulated update
+    /// can move the average by at most `1 / MIN_TWAP_WINDOW` of its range.
+    pub fn get_twap(env: Env) -> i128 {
+        let obs: Vec<Observation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Observations)
+            .unwrap_or(Vec::new(&env));
+
+        assert!(!obs.is_empty(), "no observations recorded");
+
+        let mut sum: i128 = 0;
+        for o in obs.iter() {
+            sum += o.price;
+        }
+        sum / obs.len() as i128
+    }
+
+    /// Return the configured window size.
+    pub fn get_window(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Window)
+            .unwrap_or(0)
+    }
+
+    /// Return the number of observations currently in the buffer.
+    pub fn observation_count(env: Env) -> u32 {
+        let obs: Vec<Observation> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Observations)
+            .unwrap_or(Vec::new(&env));
+        obs.len()
+    }
+}


### PR DESCRIPTION
A TWAP oracle that accepts window = 1 collapses the average into a spot price. A single manipulated update immediately becomes the "average" — zero manipulation resistance.

Fix
SecureTwap enforces MIN_TWAP_WINDOW = 10 at init, rejecting anything shorter with "twap window below minimum".

Tests
Vulnerable: window-1 accepted, one spike overwrites full TWAP history, boundary silently passes
Secure: rejects window 1 and 9, accepts window 10, confirms a 10× spike only moves TWAP to 19_000_000 not 100_000_000
closes #252 