### PR TITLE
feat(sensitive_storage): extract secure contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ flowchart TD
 | `missing_events` | No events emitted | — | Emit structured events |
 | `reward_debt_not_updated` | Reward debt not updated | _(inline `secure.rs`)_ | Update debt after payout |
 | `reward_checkpoint_missing` | Reward checkpoint missing | _(inline `secure.rs`)_ | Snapshot accumulator on deposit |
+| `sensitive_storage` | Sensitive data in storage | _(inline `secure.rs`)_ | Store only hash commitments |
 
 ### Useful links
 

--- a/docs/vulnerabilities.md
+++ b/docs/vulnerabilities.md
@@ -1219,8 +1219,8 @@ address without the depositor's consent.
 
 ## 32. Sensitive Data in Storage (`sensitive_storage`)
 
-**Contract:** `vulnerable/sensitive_storage` → inline secure pattern
-**Severity:** Critical
+**Contract:** `vulnerable/sensitive_storage` → `vulnerable/sensitive_storage/src/secure.rs`
+**Severity:** High
 
 ### What it is
 
@@ -1241,7 +1241,7 @@ pub fn initialize(env: Env, admin: Address, secret_key: Bytes) {
 ### Secure fix
 
 ```rust
-pub fn initialize_secure(env: Env, admin: Address, secret_hash: Bytes) {
+pub fn initialize(env: Env, admin: Address, secret_hash: Bytes) {
     admin.require_auth();
     // ✅ Store only a hash commitment — raw secret never touches the ledger
     env.storage().persistent().set(&DataKey::Commitment, &secret_hash);

--- a/vulnerable/sensitive_storage/src/lib.rs
+++ b/vulnerable/sensitive_storage/src/lib.rs
@@ -7,8 +7,9 @@
 //! VULNERABILITY: `initialize()` writes raw secret material to persistent
 //! storage, exposing it to anyone who can read the ledger.
 //!
-//! SECURE MIRROR: store only a SHA-256 hash commitment on-chain; keep the
-//! raw secret in off-chain key management infrastructure.
+//! SECURE MIRROR: see `secure.rs`, which stores only a SHA-256 hash
+//! commitment on-chain and keeps the raw secret in off-chain key management
+//! infrastructure.
 
 #![no_std]
 use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env};
@@ -19,6 +20,8 @@ pub enum DataKey {
     SecretKey,
     Commitment,
 }
+
+pub mod secure;
 
 #[contract]
 pub struct SensitiveStorageContract;
@@ -53,28 +56,6 @@ impl SensitiveStorageContract {
             .persistent()
             .get(&DataKey::Admin)
             .expect("admin not initialized")
-    }
-
-    // -------------------------------------------------------------------------
-    // Secure mirror — stores only a hash commitment, never the raw secret.
-    // -------------------------------------------------------------------------
-
-    /// SECURE: stores only a hash commitment — the raw secret never touches the ledger.
-    pub fn initialize_secure(env: Env, admin: Address, secret_hash: Bytes) {
-        admin.require_auth();
-        env.storage().persistent().set(&DataKey::Admin, &admin);
-        // ✅ Only the hash is stored — the raw secret never touches the ledger
-        env.storage()
-            .persistent()
-            .set(&DataKey::Commitment, &secret_hash);
-    }
-
-    /// Returns the stored hash commitment.
-    pub fn get_commitment(env: Env) -> Bytes {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Commitment)
-            .expect("commitment not set")
     }
 }
 
@@ -116,27 +97,5 @@ mod tests {
         // No auth mock needed — get_secret has no access control
         let stolen = client.get_secret();
         assert_eq!(stolen, secret);
-    }
-
-    #[test]
-    fn test_secure_stores_only_commitment() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let contract_id = env.register_contract(None, SensitiveStorageContract);
-        let client = SensitiveStorageContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        // Simulate a SHA-256 hash (32 bytes) — raw secret never sent on-chain
-        let hash = Bytes::from_slice(&env, &[0xab_u8; 32]);
-
-        client.initialize_secure(&admin, &hash);
-
-        let stored_commitment = client.get_commitment();
-        assert_eq!(stored_commitment, hash);
-        // Raw secret is never stored — DataKey::SecretKey is absent
-        let has_secret_key = env.as_contract(&contract_id, || {
-            env.storage().persistent().has(&DataKey::SecretKey)
-        });
-        assert!(!has_secret_key);
     }
 }

--- a/vulnerable/sensitive_storage/src/secure.rs
+++ b/vulnerable/sensitive_storage/src/secure.rs
@@ -1,0 +1,95 @@
+//! SECURE: stores only a hash commitment, never raw secret material.
+//!
+//! All Soroban ledger state is public, so API keys, private keys, seeds, and
+//! other raw secrets must stay off-chain. This mirror stores only a public
+//! commitment that callers can compare against off-chain secret material.
+
+use super::DataKey;
+use soroban_sdk::{contract, contractimpl, Address, Bytes, Env};
+
+#[contract]
+pub struct SecureStorageContract;
+
+#[contractimpl]
+impl SecureStorageContract {
+    /// SECURE: stores only a hash commitment; raw secrets never touch storage.
+    pub fn initialize(env: Env, admin: Address, secret_hash: Bytes) {
+        if env.storage().persistent().has(&DataKey::Commitment) {
+            panic!("already initialized");
+        }
+
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        // ✅ Only the hash commitment is stored on-chain.
+        env.storage()
+            .persistent()
+            .set(&DataKey::Commitment, &secret_hash);
+    }
+
+    /// Returns the stored public hash commitment.
+    pub fn get_commitment(env: Env) -> Bytes {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Commitment)
+            .expect("commitment not set")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Bytes, Env};
+
+    #[test]
+    fn test_secure_stores_hash_not_secret() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SecureStorageContract);
+        let client = SecureStorageContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let hash = Bytes::from_slice(&env, &[0xab_u8; 32]);
+
+        client.initialize(&admin, &hash);
+
+        assert_eq!(client.get_commitment(), hash);
+        let has_secret_key = env.as_contract(&contract_id, || {
+            env.storage().persistent().has(&DataKey::SecretKey)
+        });
+        assert!(!has_secret_key);
+        // SecureStorageContractClient has no get_secret method because the
+        // secure contract never exposes raw secret material.
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_secure_initialize_requires_admin_auth() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SecureStorageContract);
+        let client = SecureStorageContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let hash = Bytes::from_slice(&env, &[0xcd_u8; 32]);
+
+        client.initialize(&admin, &hash);
+    }
+
+    #[test]
+    #[should_panic(expected = "already initialized")]
+    fn test_secure_commitment_is_deterministic() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SecureStorageContract);
+        let client = SecureStorageContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let hash = Bytes::from_slice(&env, &[0xef_u8; 32]);
+
+        client.initialize(&admin, &hash);
+        assert_eq!(client.get_commitment(), hash);
+
+        // Re-initialization is blocked, so the stored commitment cannot be
+        // overwritten after the first deterministic write.
+        client.initialize(&admin, &hash);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the sensitive-storage secure mirror into `src/secure.rs` as a separate `SecureStorageContract`.
- Remove the inline secure methods from the vulnerable contract while keeping the vulnerable API intact.
- Add secure-side tests for hash-only storage, required admin auth, and re-initialization protection.
- Update README and vulnerability docs to point at the dedicated secure implementation.

## Verification

- `cargo test -p sensitive-storage`
- `cargo build -p sensitive-storage`
- `/usr/bin/cargo-fmt -