### PR TITLE
feat: add secure contract for reward checkpoint missing vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "vulnerable/no_min_stake",
     "vulnerable/operator_role_not_enforced",
     "vulnerable/reentrancy",
+    "vulnerable/reward_checkpoint_missing",
     "vulnerable/reinit_attack",
     "vulnerable/scanner_impersonation",
     "vulnerable/self_stake",

--- a/docs/vulnerabilities.md
+++ b/docs/vulnerabilities.md
@@ -386,7 +386,75 @@ and extract unlimited rewards from a single stake.
 
 ---
 
-## 11. Division by Zero (`div_by_zero`)
+## 11. Reward Checkpoint Missing (`reward_checkpoint_missing`)
+
+**Contract:** `vulnerable/reward_checkpoint_missing` → `vulnerable/reward_checkpoint_missing/src/secure.rs`
+**Severity:** High
+
+### What it is
+
+A staking contract using the standard MasterChef-style global accumulator pattern
+fails to snapshot the accumulator into the user's `reward_debt` when new stake is
+added. The `reward_debt` is meant to record the accumulator value at deposit time,
+so that pending rewards only accrue from that point forward. Without this checkpoint,
+a late depositor inherits a debt of 0 and can immediately claim all accumulated
+rewards that were earned before they joined.
+
+### Vulnerable pattern
+
+```rust
+pub fn stake(env: Env, user: Address, amount: u64) {
+    user.require_auth();
+    let acc = get_acc(&env);
+    let current_stake = get_stake(&env, &user);
+
+    // ❌ Missing: set_reward_debt(&env, &user, acc * (current_stake + amount));
+    // debt defaults to 0, so a late depositor can claim all historical rewards
+    env.storage().persistent().set(
+        &DataKey::Stake(user.clone()),
+        &(current_stake + amount)
+    );
+}
+```
+
+Pending rewards are computed as:
+```
+pending = (acc_reward_per_share × user_stake) - user_reward_debt
+```
+
+Without the checkpoint, `debt = 0`, so `pending = acc × stake`, which includes
+all rewards earned before the user even joined.
+
+### Secure fix
+
+```rust
+pub fn stake(env: Env, user: Address, amount: u64) {
+    user.require_auth();
+    let new_total_stake = get_stake_secure(&env, &user).saturating_add(amount);
+    let acc = get_acc_secure(&env);
+
+    // Write the new balance
+    env.storage().persistent().set(
+        &SecureDataKey::Stake(user.clone()),
+        &new_total_stake
+    );
+
+    // ✅ FIX: Set reward_debt to the current accumulator × new stake.
+    // This captures the checkpoint so pending = 0 at deposit time.
+    let new_debt = acc.saturating_mul(new_total_stake) / 1_000_0000;
+    set_debt_secure(&env, &user, new_debt);
+}
+```
+
+### Impact
+
+Historical reward theft: a user who deposits after rewards have already accrued
+can immediately claim those pre-deposit rewards as if they had been staking all
+along. This allows late depositors to extract far more than they contributed.
+
+---
+
+## 12. Division by Zero (`div_by_zero`)
 
 **Contract:** `vulnerable/div_by_zero` → inline secure pattern
 **Severity:** Medium

--- a/vulnerable/reward_checkpoint_missing/Cargo.toml
+++ b/vulnerable/reward_checkpoint_missing/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
-crate-type = ["rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/vulnerable/reward_checkpoint_missing/Cargo.toml
+++ b/vulnerable/reward_checkpoint_missing/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT"
 repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["rlib"]
 
 [dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/vulnerable/reward_checkpoint_missing/Cargo.toml
+++ b/vulnerable/reward_checkpoint_missing/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/Veritas-Vaults-Network/soroban-guard-contracts"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = { workspace = true }
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/vulnerable/reward_checkpoint_missing/src/lib.rs
+++ b/vulnerable/reward_checkpoint_missing/src/lib.rs
@@ -173,4 +173,5 @@ mod tests {
     }
 }
 
-pub mod secure;
+#[cfg(test)]
+mod secure;

--- a/vulnerable/reward_checkpoint_missing/src/lib.rs
+++ b/vulnerable/reward_checkpoint_missing/src/lib.rs
@@ -172,3 +172,5 @@ mod tests {
         assert!(reward > 0, "post-deposit rewards accrue correctly");
     }
 }
+
+pub mod secure;

--- a/vulnerable/reward_checkpoint_missing/src/secure.rs
+++ b/vulnerable/reward_checkpoint_missing/src/secure.rs
@@ -1,0 +1,198 @@
+//! SECURE: Reward Checkpoint Fixed
+//!
+//! A corrected staking contract that properly snapshots the accumulator into
+//! the user's reward checkpoint. When stake() is called, reward_debt is
+//! immediately set to acc * new_stake, ensuring users only earn rewards from
+//! the moment they deposit forward.
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+pub enum SecureDataKey {
+    /// Global accumulated reward per staked token (scaled ×1e7).
+    AccRewardPerShare,
+    /// Amount staked by each user.
+    Stake(Address),
+    /// Reward debt: acc_reward_per_share × stake at the time of last deposit/claim.
+    RewardDebt(Address),
+}
+
+fn get_acc_secure(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&SecureDataKey::AccRewardPerShare)
+        .unwrap_or(0)
+}
+
+fn get_stake_secure(env: &Env, user: &Address) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&SecureDataKey::Stake(user.clone()))
+        .unwrap_or(0)
+}
+
+fn get_debt_secure(env: &Env, user: &Address) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&SecureDataKey::RewardDebt(user.clone()))
+        .unwrap_or(0)
+}
+
+fn set_debt_secure(env: &Env, user: &Address, debt: u64) {
+    env.storage()
+        .persistent()
+        .set(&SecureDataKey::RewardDebt(user.clone()), &debt);
+}
+
+#[contract]
+pub struct SecureStaking;
+
+#[contractimpl]
+impl SecureStaking {
+    pub fn initialize(env: Env, acc_reward_per_share: u64) {
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::AccRewardPerShare, &acc_reward_per_share);
+    }
+
+    /// Advance the global accumulator (called by keeper / admin).
+    pub fn add_rewards(env: Env, reward_per_share_delta: u64) {
+        let acc = get_acc_secure(&env).saturating_add(reward_per_share_delta);
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::AccRewardPerShare, &acc);
+    }
+
+    /// ✅ SECURE: Records the new stake balance AND immediately sets reward_debt
+    /// to the current accumulator value. This ensures users only earn rewards
+    /// from the moment they deposit, not from historical rewards.
+    pub fn stake(env: Env, user: Address, amount: u64) {
+        user.require_auth();
+        let new_total_stake = get_stake_secure(&env, &user).saturating_add(amount);
+        let acc = get_acc_secure(&env);
+
+        // Write the new balance
+        env.storage()
+            .persistent()
+            .set(&SecureDataKey::Stake(user.clone()), &new_total_stake);
+
+        // ✅ FIX: Set reward_debt to the current accumulator × new stake.
+        // This captures the checkpoint, so pending = 0 at deposit time.
+        let new_debt = acc.saturating_mul(new_total_stake) / 1_000_0000;
+        set_debt_secure(&env, &user, new_debt);
+    }
+
+    /// Pays out pending rewards. Now only covers the window after stake() was called.
+    pub fn claim_rewards(env: Env, user: Address) -> u64 {
+        user.require_auth();
+        let stake = get_stake_secure(&env, &user);
+        let acc = get_acc_secure(&env);
+        let entitled = acc.saturating_mul(stake) / 1_000_0000;
+        let debt = get_debt_secure(&env, &user);
+        let pending = entitled.saturating_sub(debt);
+        // Update debt so repeated claims don't double-pay.
+        set_debt_secure(&env, &user, entitled);
+        pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    fn setup_with_existing_rewards() -> (Env, SecureStakingClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureStaking);
+        let client = SecureStakingClient::new(&env, &id);
+        // Rewards already accrued before the late depositor arrives.
+        client.initialize(&5_000_000_000);
+        let late_user = Address::generate(&env);
+        (env, client, late_user)
+    }
+
+    /// ✅ Test: Late staker cannot claim pre-deposit rewards.
+    /// After staking with the checkpoint fix, immediate claim_rewards returns 0.
+    #[test]
+    fn test_secure_late_staker_cannot_claim_past_rewards() {
+        let (_env, client, user) = setup_with_existing_rewards();
+        client.stake(&user, &1_000);
+        // With the fix: debt = 5_000_000_000 * 1_000 / 10_000_000 = 500_000
+        // pending = entitled - debt = (5_000_000_000 * 1_000 / 10_000_000) - 500_000 = 0
+        let reward = client.claim_rewards(&user);
+        assert_eq!(
+            reward, 0,
+            "secure: late staker cannot claim pre-deposit rewards"
+        );
+    }
+
+    /// ✅ Test: Early staker (before any rewards) earns correctly.
+    /// Stake initially, distribute rewards, claim; verify reward = elapsed_acc × stake.
+    #[test]
+    fn test_secure_early_staker_earns_correctly() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureStaking);
+        let client = SecureStakingClient::new(&env, &id);
+        client.initialize(&0); // Start with no accumulated rewards
+        let user = Address::generate(&env);
+
+        // User stakes before any rewards accrue
+        client.stake(&user, &1_000);
+        // debt = 0 * 1_000 / 10_000_000 = 0
+
+        // Now add rewards
+        client.add_rewards(&5_000_000_000);
+        // acc is now 5_000_000_000
+
+        // Claim: pending = (5_000_000_000 * 1_000 / 10_000_000) - 0 = 500_000
+        let reward = client.claim_rewards(&user);
+        assert_eq!(reward, 500_000, "early staker earns correctly");
+    }
+
+    /// ✅ Test: Increasing stake resets debt correctly.
+    /// Initial stake + rewards, then increase stake; verify only the new window
+    /// generates rewards, not a windfall from missed debt update.
+    #[test]
+    fn test_secure_stake_increase_resets_debt() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let id = env.register_contract(None, SecureStaking);
+        let client = SecureStakingClient::new(&env, &id);
+        client.initialize(&0);
+        let user = Address::generate(&env);
+
+        // Initial stake
+        client.stake(&user, &1_000);
+        // debt = 0 * 1_000 / 10_000_000 = 0
+
+        // Add rewards
+        client.add_rewards(&2_000_000_000);
+        // acc = 2_000_000_000
+
+        // Claim to consume the first window
+        let first_reward = client.claim_rewards(&user);
+        // pending = (2_000_000_000 * 1_000 / 10_000_000) - 0 = 200_000
+        assert_eq!(first_reward, 200_000);
+        // After claim, debt = 200_000
+
+        // Add more rewards
+        client.add_rewards(&3_000_000_000);
+        // acc = 5_000_000_000
+
+        // Increase stake by 500
+        client.stake(&user, &500);
+        // new_total = 1_500, new_debt = 5_000_000_000 * 1_500 / 10_000_000 = 750_000
+
+        // Claim again: should only include rewards earned since the stake increase
+        let second_reward = client.claim_rewards(&user);
+        // entitled = 5_000_000_000 * 1_500 / 10_000_000 = 750_000
+        // debt before claim = 750_000 (set at stake increase time)
+        // pending = 750_000 - 750_000 = 0
+        assert_eq!(
+            second_reward, 0,
+            "stake increase resets debt; no windfall on claim"
+        );
+    }
+}


### PR DESCRIPTION
## Summary                                                                                                                                      
                                         
  Implements SecureStaking contract that fixes the missing reward_debt checkpoint vulnerability. When `stake()` is called, `reward_debt` is now   
  set to `acc × new_stake`, preventing late depositors from claiming historical rewards.
                                                                                                                                                  
  ## Changes                                                

  - **New File:** `vulnerable/reward_checkpoint_missing/src/secure.rs` - SecureStaking contract with the fix
  - **Updated:** `vulnerable/reward_checkpoint_missing/src/lib.rs` - Added `pub mod secure;`                                                      
  - **Updated:** `vulnerable/reward_checkpoint_missing/Cargo.toml` - Added testutils feature
  - **Updated:** Root `Cargo.toml` - Added package to workspace members                                                                           
  - **Updated:** `docs/vulnerabilities.md` - Added vulnerability #11 documentation                                                                
                                                                                                                                                  
  ## Test Coverage                                                                                                                                
                                                            
  All 6 tests passing:
                                                                                                                                                  
  - ✅ `test_secure_late_staker_cannot_claim_past_rewards` - Late depositor cannot claim pre-deposit rewards
  - ✅ `test_secure_early_staker_earns_correctly` - Early staker earns correctly from deposit time                                                
  - ✅ `test_secure_stake_increase_resets_debt` - Stake increase properly resets reward checkpoint                                                
  - ✅ `test_late_depositor_claims_historical_rewards` - Demonstrates vulnerable contract bug                                                     
  - ✅ `test_post_deposit_rewards_still_accrue` - Vulnerable contract earns post-deposit correctly                                                
  - ✅ `test_secure_checkpoint_on_stake_yields_zero_pending` - Vulnerable contract can simulate fix                                               
                                                                                                                                                  
  ## Verification                                                                                                                                 
                                                                                                                                                  
  - ✅ `cargo build -p reward-checkpoint-missing` - Clean build                                                                                   
  - ✅ `cargo test -p reward-checkpoint-missing` - All tests pass (6/6)
  - ✅ `cargo fmt --check` - Formatting validated                                                                                                 
  - ✅ `cargo build --release` - Release build successful   
closes #421 