### PR TITLE
fix(self_transfer): add secure mirror guarding against self-transfer …

### DIFF
--- a/docs/vulnerabilities.md
+++ b/docs/vulnerabilities.md
@@ -151,16 +151,18 @@ be forged or wiped by any attacker.
 
 ## 5. Self-Transfer Balance Inflation (`self_transfer`)
 
-**Contract:** `vulnerable/self_transfer` → `secure/secure_transfer`
-**Severity:** Medium
+**Contract:** `vulnerable/self_transfer` → `vulnerable/self_transfer/src/secure.rs`
+**Severity:** High
 
 ### What it is
 
 When `transfer(from, to, amount)` is called with `from == to`, both balance
 reads resolve to the same persistent storage slot. The function reads the
-balance into two separate variables, subtracts from the first write, then
-overwrites that slot with the second write — inflating the account balance by
-`amount`.
+balance into two separate variables (`from_balance` and `to_balance`, both equal
+to the original balance), subtracts `amount` on the first write, then overwrites
+that same slot with `to_balance + amount` on the second write. The credit write
+clobbers the debit write, so the account ends with `original + amount` instead of
+`original` — inflating the balance by `amount`.
 
 ### Vulnerable pattern
 
@@ -179,11 +181,16 @@ pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
 
 ```rust
 pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
-    assert!(from != to, "self-transfer not allowed"); // ✅ Guard before any storage access
     from.require_auth();
+    if from == to { return; } // ✅ FIX: no-op self-transfer, guard before any storage read
     // ...
 }
 ```
+
+A self-transfer is treated as a no-op (the common token-standard behaviour), so
+the colliding debit and credit writes never happen. `panic!("self-transfer not
+allowed")` would be an equally valid choice. The guard sits before any storage
+read so the corrupting double-write is unreachable.
 
 ### Impact
 

--- a/vulnerable/self_transfer/src/lib.rs
+++ b/vulnerable/self_transfer/src/lib.rs
@@ -75,6 +75,11 @@ impl VulnerableToken {
     }
 }
 
+// Secure mirror; gated behind cfg(test) so its #[contract] symbols don't
+// collide with the vulnerable contract's in the cdylib wasm build.
+#[cfg(test)]
+mod secure;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/vulnerable/self_transfer/src/secure.rs
+++ b/vulnerable/self_transfer/src/secure.rs
@@ -1,0 +1,120 @@
+//! SECURE: Self-Transfer Storage-Slot Collision fixed.
+//!
+//! The only change from the vulnerable contract is a single guard at the top of
+//! `transfer`: when `from == to`, both balance keys resolve to the same storage
+//! slot and the credit write overwrites the debit write, inflating the sender's
+//! balance. Returning early (a no-op self-transfer) prevents the double-write
+//! entirely. The `from.require_auth()` check is preserved unchanged.
+
+use super::{get_balance, set_balance};
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+#[contract]
+pub struct SecureToken;
+
+#[contractimpl]
+impl SecureToken {
+    /// Mint `amount` tokens to `to`. No auth check — unprotected by design for test setup.
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let current = get_balance(&env, &to);
+        set_balance(
+            &env,
+            &to,
+            current.checked_add(amount).expect("mint overflow"),
+        );
+    }
+
+    /// Returns the current balance of `account`, defaulting to 0.
+    pub fn balance(env: Env, account: Address) -> i128 {
+        get_balance(&env, &account)
+    }
+
+    /// SECURE: transfers `amount` from `from` to `to`.
+    ///
+    /// Treats a self-transfer as a no-op so the debit and credit writes can never
+    /// collide on the same storage slot.
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+
+        // ✅ FIX: guard against self-transfer before any storage reads. When
+        // `from == to` both balance keys map to the same slot, so the credit
+        // write would overwrite the debit write and inflate the balance.
+        // Returning early makes a self-transfer a no-op (the common token
+        // standard behaviour), leaving the balance unchanged.
+        if from == to {
+            return;
+        }
+
+        let from_balance = get_balance(&env, &from);
+        let to_balance = get_balance(&env, &to);
+        set_balance(
+            &env,
+            &from,
+            from_balance
+                .checked_sub(amount)
+                .expect("transfer underflow"),
+        );
+        set_balance(
+            &env,
+            &to,
+            to_balance.checked_add(amount).expect("transfer overflow"),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    /// Self-transfer is a no-op: alice's balance is unchanged, not inflated.
+    #[test]
+    fn test_secure_self_transfer_is_no_op() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SecureToken);
+        let client = SecureTokenClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        env.mock_all_auths();
+
+        client.mint(&alice, &1000);
+        client.transfer(&alice, &alice, &500);
+
+        // Balance is still 1000, not 1500 (the vulnerable inflation result).
+        assert_eq!(client.balance(&alice), 1000);
+    }
+
+    #[test]
+    fn test_secure_normal_transfer_works() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SecureToken);
+        let client = SecureTokenClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+        env.mock_all_auths();
+
+        client.mint(&alice, &500);
+        client.mint(&bob, &100);
+
+        client.transfer(&alice, &bob, &200);
+
+        assert_eq!(client.balance(&alice), 300);
+        assert_eq!(client.balance(&bob), 300);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_secure_transfer_requires_from_auth() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, SecureToken);
+        let client = SecureTokenClient::new(&env, &contract_id);
+
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &500);
+        // No mock_all_auths — should panic on require_auth.
+        client.transfer(&alice, &bob, &100);
+    }
+}


### PR DESCRIPTION
closes #420

Add vulnerable/self_transfer/src/secure.rs with a SecureToken contract that treats a self-transfer (from == to) as a no-op, preventing the storage-slot collision where the credit write overwrites the debit write and inflates the balance. Wire it via a cfg(test)-gated secure module and document the fix in docs/vulnerabilities.md (severity raised to High).